### PR TITLE
html2text: add a basic command-line parser.

### DIFF
--- a/examples/html2text.rs
+++ b/examples/html2text.rs
@@ -1,8 +1,45 @@
 extern crate html2text;
+#[cfg(unix)] extern crate argparse;
 use std::io;
+use std::io::Write;
+use argparse::{ArgumentParser, Store, StoreOption};
+
 
 fn main() {
-    let stdin = io::stdin();
+    let mut infile : Option<String> = None;
+    let mut outfile : Option<String> = None;
+    let mut width : usize = 80;
 
-    println!("{}", html2text::from_read(&mut stdin.lock(), 80));
+    {
+        let mut ap = ArgumentParser::new();
+        ap.refer(&mut infile)
+            .add_argument("infile", StoreOption, "Input HTML file (default is standard input)");
+        ap.refer(&mut width)
+            .add_option(&["-w", "--width"], Store, "Column width to format to (default is 80)");
+        ap.refer(&mut outfile)
+            .add_option(&["-o", "--output"], StoreOption, "Output file (default is standard output)");
+        ap.parse_args_or_exit();
+    }
+
+    let data = match infile {
+        None => {
+            let stdin = io::stdin();
+            let data = html2text::from_read(&mut stdin.lock(), width);
+            data
+        },
+        Some(name) => {
+            let mut file = std::fs::File::open(name).expect("Tried to open file");
+            html2text::from_read(&mut file, width)
+        },
+    };
+
+    match outfile {
+        None => {
+            println!("{}", data);
+        },
+        Some(name) => {
+            let mut file = std::fs::File::create(name).expect("Tried to create file");
+            write!(file, "{}", data).unwrap();
+        },
+    };
 }


### PR DESCRIPTION
I've used the same argument-parsing crate as html2term, and used it to
implement a command-line option to set the column width of the
formatted output.

While I'm at it, I've also allowed specifying an input file name as a
positional argument, and the usual -o option to write to an output
file, so that html2text doesn't always have to be used with its
standard I/O handles redirected. However, the default behaviour if
neither of those options is present is to read from standard input and
write to standard output, so this change should be backwards
compatible in the sense that html2text run without arguments should
continue to do what it always has done. (However, running it _with_
arguments will now change behaviour, because the arguments aren't
ignored any more!)

This patch would look nicer if my Rust were good enough to figure out
how to set a variable to either stdin or the result of opening a file,
so that I could have just one call to html2text::from_read, and
similarly on output. But it's not. Sorry about that.