### PR TITLE
Issue 2 deeply nested

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,9 +133,8 @@ pub struct RenderTableCell {
 
 impl RenderTableCell {
     /// Render this cell to a builder.
-    pub fn render<T:Write, R:Renderer>(&mut self, builder: &mut R, err_out: &mut T)
+    pub fn render<T:Write, R:Renderer>(&mut self, _builder: &mut R, _err_out: &mut T)
     {
-    unimplemented!()
         //render_tree_children_to_string(builder, &mut self.content, err_out)
     }
 
@@ -705,9 +704,9 @@ fn process_dom_node<T:Write>(handle: Handle, err_out: &mut T) -> TreeMapResult<(
     }
 }
 
-fn render_tree_children_to_string<T:Write, R:Renderer>(builder: &mut R,
-                                                      children: &mut Vec<RenderNode>,
-                                                      err_out: &mut T) {
+fn render_tree_children_to_string<T:Write, R:Renderer>(_builder: &mut R,
+                                                      _children: &mut Vec<RenderNode>,
+                                                      _err_out: &mut T) {
     unimplemented!()
     /*
     for child in children {
@@ -879,7 +878,7 @@ fn do_render_node<'a, 'b, T: Write, R: Renderer>(builder: &mut BuilderStack<R>,
                 children: items,
                 cons: Box::new(|_, _| Some(())),
                 prefn: Some(Box::new(|builder: &mut BuilderStack<R>, _| {
-                    let mut sub_builder = builder.new_sub_renderer(builder.width()-2);
+                    let sub_builder = builder.new_sub_renderer(builder.width()-2);
                     builder.push(sub_builder);
                 })),
                 postfn: Some(Box::new(|builder: &mut BuilderStack<R>, _| {
@@ -901,7 +900,7 @@ fn do_render_node<'a, 'b, T: Write, R: Renderer>(builder: &mut BuilderStack<R>,
                 children: items,
                 cons: Box::new(|_, _| Some(())),
                 prefn: Some(Box::new(move |builder: &mut BuilderStack<R>, _| {
-                    let mut sub_builder = builder.new_sub_renderer(builder.width()-prefix_width);
+                    let sub_builder = builder.new_sub_renderer(builder.width()-prefix_width);
                     builder.push(sub_builder);
                 })),
                 postfn: Some(Box::new(move |builder: &mut BuilderStack<R>, _| {
@@ -922,10 +921,6 @@ fn do_render_node<'a, 'b, T: Write, R: Renderer>(builder: &mut BuilderStack<R>,
             render_table_tree(builder.deref_mut(), &mut tab, err_out);
             Finished(())
         },
-        dummy => {
-            eprintln!("{:?}", dummy);
-            unimplemented!()
-        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -823,15 +823,19 @@ fn do_render_node<'a, 'b, T: Write, R: Renderer>(builder: &mut BuilderStack<R>,
             builder.add_preformatted_block(formatted);
             Finished(())
         },
-        /*
-        BlockQuote(ref mut children) => {
+        BlockQuote(children) => {
             let mut sub_builder = builder.new_sub_renderer(builder.width()-2);
-            render_tree_children_to_string(&mut sub_builder, children, err_out);
+            builder.push(sub_builder);
+            pending2(children, |builder: &mut BuilderStack<R>, _| {
+                let sub_builder = builder.pop();
 
-            builder.start_block();
-            builder.append_subrender(sub_builder, repeat("> "));
-            builder.end_block();
+                builder.start_block();
+                builder.append_subrender(sub_builder, repeat("> "));
+                builder.end_block();
+                Some(())
+            })
         },
+        /*
         Ul(ref mut items) => {
             builder.start_block();
             for item in items {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -499,7 +499,7 @@ fn tree_map_reduce<N, R, M, C>(top: N,
             to_process: vec![top].into_iter(),
         }
     ];
-    let result = loop {
+    loop {
         // Get the next child node to process
         let next_node = pending_stack.last_mut()
                                      .unwrap()
@@ -532,19 +532,19 @@ fn tree_map_reduce<N, R, M, C>(top: N,
                 }
             }
         }
-    };
-
-    html_trace!("### dom_to_render_tree: HTML: {:?}", node);
-    html_trace!("### dom_to_render_tree: out= {:#?}", result);
-    result
+    }
 }
 
 /// Convert a DOM tree or subtree into a render tree.
 pub fn dom_to_render_tree<T:Write>(handle: Handle, err_out: &mut T) -> Option<RenderNode> {
-    tree_map_reduce(handle,
+    let result = tree_map_reduce(handle,
                     |handle| process_node(handle, err_out),
                     |handle| handle.children.borrow().clone()
-                )
+                );
+
+    html_trace!("### dom_to_render_tree: HTML: {:?}", handle);
+    html_trace!("### dom_to_render_tree: out= {:#?}", result);
+    result
 }
 
 fn pending<F: Fn(Vec<RenderNode>) -> Option<RenderNode> + 'static>(handle: Handle, f: F) -> TreeMapResult<Handle, RenderNode> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -416,7 +416,6 @@ fn list_children_to_render_nodes<T:Write>(handle: Handle, err_out: &mut T) -> Ve
 /// Convert a table into a RenderNode
 fn table_to_render_tree<T:Write>(handle: Handle, _err_out: &mut T) ->  TreeMapResult<(), Handle, RenderNode> {
     pending(handle, |_,rowset| {
-        eprintln!("making a table");
         let mut rows = vec![];
         for bodynode in rowset {
             if let RenderNodeInfo::TableBody(body) = bodynode.info {
@@ -432,7 +431,6 @@ fn table_to_render_tree<T:Write>(handle: Handle, _err_out: &mut T) ->  TreeMapRe
 /// Add rows from a thead or tbody.
 fn tbody_to_render_tree<T:Write>(handle: Handle, _err_out: &mut T) ->  TreeMapResult<(), Handle, RenderNode> {
     pending(handle, |_,rowchildren| {
-        eprintln!("Making a tbody");
         let rows = rowchildren.into_iter()
                               .flat_map(|rownode| {
                                   if let RenderNodeInfo::TableRow(row) = rownode.info {
@@ -449,7 +447,6 @@ fn tbody_to_render_tree<T:Write>(handle: Handle, _err_out: &mut T) ->  TreeMapRe
 /// Convert a table row to a RenderTableRow
 fn tr_to_render_tree<T:Write>(handle: Handle, _err_out: &mut T) ->  TreeMapResult<(), Handle, RenderNode> {
     pending(handle, |_, cellnodes| {
-        eprintln!("Making a tr");
         let cells = cellnodes.into_iter()
                              .flat_map(|cellnode| {
                                  if let RenderNodeInfo::TableCell(cell) = cellnode.info {
@@ -475,7 +472,6 @@ fn td_to_render_tree<T:Write>(handle: Handle, _err_out: &mut T) ->  TreeMapResul
         }
     }
     pending(handle, move |_, children| {
-        eprintln!("Making a td");
         Some(RenderNode::new(RenderNodeInfo::TableCell(RenderTableCell {
             colspan: colspan,
             content: children,
@@ -1657,5 +1653,23 @@ Hi foo, bar
                          .collect::<Vec<_>>()
                          .concat();
         test_html(html.as_bytes(), "", 10);
+    }
+
+    #[test]
+    fn test_deeply_nested_table() {
+        use ::std::iter::repeat;
+        let html = repeat("<table><tr><td>hi</td><td>")
+                         .take(1000)
+                         .collect::<Vec<_>>()
+                         .concat()
+                 + &repeat("</td></tr></table>")
+                         .take(1000)
+                         .collect::<Vec<_>>()
+                         .concat();
+        test_html(html.as_bytes(), r#"────┬─┬───
+hi  │h│   
+    │i│   
+────┴─┴───
+"#, 10);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1449,7 +1449,6 @@ Hi foo, bar
     }
 
     #[test]
-    #[ignore]
     fn test_deeply_nested() {
         use ::std::iter::repeat;
         let html = repeat("<foo>")

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -5,15 +5,11 @@ pub mod text_renderer;
 
 /// A type which is a backend for HTML to text rendering.
 pub trait Renderer {
-    /// A type of a sub-renderer which will be used for rendering
-    /// nested blocks such as table cells and list items.
-    type Sub: Renderer;
-
     /// Add an empty line to the output (ie between blocks).
     fn add_empty_line(&mut self);
 
     /// Create a sub-renderer for nested blocks.
-    fn new_sub_renderer(&self, width: usize) -> Self::Sub;
+    fn new_sub_renderer(&self, width: usize) -> Self;
 
     /// Start a new block.
     fn start_block(&mut self);
@@ -40,17 +36,17 @@ pub trait Renderer {
     /// Add a line to the current block without starting a new one.
     fn add_block_line(&mut self, line: &str);
 
-    /// Add a new block from a Sub, and prefix every line by the
+    /// Add a new block from a sub renderer, and prefix every line by the
     /// corresponding text from each iteration of prefixes.
-    fn append_subrender<'a, I>(&mut self, other: Self::Sub, prefixes: I)
+    fn append_subrender<'a, I>(&mut self, other: Self, prefixes: I)
                            where I:Iterator<Item=&'a str>;
 
-    /// Append a set of Sub joined left-to-right with a vertical line,
+    /// Append a set of sub renderers joined left-to-right with a vertical line,
     /// and add a horizontal line below.
     /// If collapse is true, then merge top/bottom borders of the subrenderer
     /// with the surrounding one.
     fn append_columns_with_borders<I>(&mut self, cols: I, collapse: bool)
-                           where I:IntoIterator<Item=Self::Sub>;
+                           where I:IntoIterator<Item=Self>, Self: Sized;
 
     /// Returns true if this renderer has no content.
     fn empty(&self) -> bool;

--- a/src/render/text_renderer.rs
+++ b/src/render/text_renderer.rs
@@ -579,7 +579,6 @@ impl<D:TextDecorator> TextRenderer<D> {
 }
 
 impl<D:TextDecorator> Renderer for TextRenderer<D> {
-    type Sub = Self;
     fn add_empty_line(&mut self) {
         html_trace!("add_empty_line()");
         self.flush_all();


### PR DESCRIPTION
Convert the function-call recursion to use an explicit stack of unfinished work, to avoid overflowing the call stack.