### PR TITLE
html2text: add a --literal option to omit markup.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,8 @@ mod macros;
 pub mod render;
 
 use render::Renderer;
-use render::text_renderer::{TextRenderer,PlainDecorator,RichDecorator,
+use render::text_renderer::{TextRenderer,
+                            TextDecorator,PlainDecorator,RichDecorator,
                             RichAnnotation,TaggedLine,RenderLine};
 
 use std::io;
@@ -1150,9 +1151,12 @@ fn render_table_cell<T:Write, R:Renderer>(_builder: &mut R, cell: RenderTableCel
     })
 }
 
-/// Reads HTML from `input`, and returns a `String` with text wrapped to
-/// `width` columns.
-pub fn from_read<R>(mut input: R, width: usize) -> String where R: io::Read {
+/// Reads HTML from `input`, decorates it using `decorator`, and
+/// returns a `String` with text wrapped to `width` columns.
+pub fn from_read_with_decorator<R, D>
+    (mut input: R, width: usize, decorator: D) -> String
+    where R: io::Read, D: TextDecorator
+{
     let opts = ParseOpts {
         tree_builder: TreeBuilderOpts {
             drop_doctype: true,
@@ -1165,12 +1169,18 @@ pub fn from_read<R>(mut input: R, width: usize) -> String where R: io::Read {
                    .read_from(&mut input)
                    .unwrap();
 
-    let decorator = PlainDecorator::new();
     let builder = TextRenderer::new(width, decorator);
 
     let render_tree = dom_to_render_tree(dom.document, &mut Discard{}).unwrap();
     let builder = render_tree_to_string(builder, render_tree, &mut Discard{});
     builder.into_string()
+}
+
+/// Reads HTML from `input`, and returns a `String` with text wrapped to
+/// `width` columns.
+pub fn from_read<R>(input: R, width: usize) -> String where R: io::Read {
+    let decorator = PlainDecorator::new();
+    from_read_with_decorator(input, width, decorator)
 }
 
 /// Reads HTML from `input`, and returns text wrapped to `width` columns.

--- a/src/render/text_renderer.rs
+++ b/src/render/text_renderer.rs
@@ -1121,6 +1121,80 @@ impl TextDecorator for PlainDecorator {
     }
 }
 
+/// A decorator for use with `TextRenderer` which outputs plain UTF-8 text
+/// with no annotations or markup, emitting only the literal text.
+#[derive(Clone)]
+pub struct TrivialDecorator {}
+
+impl TrivialDecorator {
+    /// Create a new `TrivialDecorator`.
+    #[cfg_attr(feature="clippy", allow(new_without_default_derive))]
+    pub fn new() -> TrivialDecorator {
+        TrivialDecorator {}
+    }
+}
+
+impl TextDecorator for TrivialDecorator {
+    type Annotation = ();
+
+    fn decorate_link_start(&mut self, _url: &str) -> (String, Self::Annotation)
+    {
+        ("".to_string(), ())
+    }
+
+    fn decorate_link_end(&mut self) -> String
+    {
+        "".to_string()
+    }
+
+    fn decorate_em_start(&mut self) -> (String, Self::Annotation)
+    {
+        ("".to_string(), ())
+    }
+
+    fn decorate_em_end(&mut self) -> String
+    {
+        "".to_string()
+    }
+
+    fn decorate_strong_start(&mut self) -> (String, Self::Annotation)
+    {
+        ("".to_string(), ())
+    }
+
+    fn decorate_strong_end(&mut self) -> String
+    {
+        "".to_string()
+    }
+
+    fn decorate_code_start(&mut self) -> (String, Self::Annotation)
+    {
+        ("".to_string(), ())
+    }
+
+    fn decorate_code_end(&mut self) -> String
+    {
+        "".to_string()
+    }
+
+    fn decorate_preformat_first(&mut self) -> Self::Annotation { () }
+    fn decorate_preformat_cont(&mut self) -> Self::Annotation { () }
+
+    fn decorate_image(&mut self, title: &str) -> (String, Self::Annotation)
+    {
+        // FIXME: this should surely be the alt text, not the title text
+        (title.to_string(), ())
+    }
+
+    fn finalise(self) -> Vec<TaggedLine<()>> {
+        Vec::new()
+    }
+
+    fn make_subblock_decorator(&self) -> Self {
+        TrivialDecorator::new()
+    }
+}
+
 /// A decorator to generate rich text (styled) rather than
 /// pure text output.
 #[derive(Clone)]


### PR DESCRIPTION
This is a useful option if the input HTML file has been generated by
an MUA which automatically inserts hyperlinks around parts of the
message that look like URLs or email addresses, and you want to
extract literal text from the message such as a shell transcript.

My technique is a bit bodgy. In text_renderer.rs I thought it was
cleaner to make a separate TrivialDecorator type than to complicate
the existing PlainDecorator with a boolean flag and endless ifs. But
then in html2text.rs I couldn't find a way to initialise a variable to
one of TrivialDecorator and PlainDecorator depending on the command-
line flag, so I used an extra layer of wrapper function, which surely
isn't the best way. But it seems to work.