### PR TITLE
Don't collapse consecutive <br>s

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1035,7 +1035,7 @@ fn do_render_node<'a, 'b, T: Write, R: Renderer>(builder: &mut BuilderStack<R>,
             }
         },
         Break => {
-            builder.new_line();
+            builder.new_line_hard();
             Finished(None)
         },
         Table(tab) => {
@@ -1579,6 +1579,18 @@ Div2
      fn test_br() {
          test_html(br"<p>Hello<br/>World</p>",
                    "Hello\nWorld\n", 20);
+     }
+
+     #[test]
+     fn test_br2() {
+         test_html(br"<p>Hello<br/><br/>World</p>",
+                   "Hello\n\nWorld\n", 20);
+     }
+
+     #[test]
+     fn test_br3() {
+         test_html(br"<p>Hello<br/> <br/>World</p>",
+                   "Hello\n\nWorld\n", 20);
      }
 
      #[test]

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -20,6 +20,9 @@ pub trait Renderer {
     /// Start a new line, if necessary (but don't add a new line).
     fn new_line(&mut self);
 
+    /// Start a new line.
+    fn new_line_hard(&mut self);
+
     /// Add a horizontal table border.
     fn add_horizontal_border(&mut self);
 

--- a/src/render/text_renderer.rs
+++ b/src/render/text_renderer.rs
@@ -677,6 +677,14 @@ impl<D:TextDecorator> Renderer for TextRenderer<D> {
         self.flush_all();
     }
 
+    fn new_line_hard(&mut self) {
+        match self.wrapping {
+            None => self.add_empty_line(),
+            Some(WrappedBlock { wordlen: 0, .. }) => self.add_empty_line(),
+            Some(_) => self.flush_all(),
+        }
+    }
+
     fn add_horizontal_border(&mut self) {
         self.flush_wrapping();
         self.lines.push(RenderLine::Line(BorderHoriz::new(self.width)));


### PR DESCRIPTION
I'm not sure if this should be configurable or not, but at least on my corpus it was pretty desirable to have consecutive \<br\>s not get collapsed.