### PR TITLE
Fix size recursion

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -968,10 +968,8 @@ impl<R:Renderer> DerefMut for BuilderStack<R> {
 fn render_tree_to_string<T:Write, R:Renderer>(builder: R, tree: RenderNode,
                           err_out: &mut T) -> R {
     /* Phase 1: get size estimates. */
-    /*
-    tree_map_reduce(&mut (), tree,
-        |_, ref node| precalc_size_estimate(node));
-        */
+    tree_map_reduce(&mut (), &tree,
+        |_, node| precalc_size_estimate(&node));
 
     /* Phase 2: actually render. */
     let mut bs = BuilderStack::new(builder);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1914,7 +1914,7 @@ Hi foo, bar
     fn test_deeply_nested() {
         use ::std::iter::repeat;
         let html = repeat("<foo>")
-                         .take(10000)
+                         .take(1000)
                          .collect::<Vec<_>>()
                          .concat();
         test_html(html.as_bytes(), "", 10);
@@ -1924,7 +1924,7 @@ Hi foo, bar
     fn test_deeply_nested_table() {
         use ::std::iter::repeat;
         let html = repeat("<table><tr><td>hi</td><td>")
-                         .take(10000)
+                         .take(1000)
                          .collect::<Vec<_>>()
                          .concat()
                  + &repeat("</td></tr></table>")


### PR DESCRIPTION
This uses `tree_map_reduce()` to do the size estimation in a separate pass before the main rendering pass, preventing the possibly very deep recursion and stack exhaustion.