### PR TITLE
Add parse function as a new entry point

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1476,7 +1476,7 @@ pub fn parse(mut input: impl io::Read) -> RenderTree {
         .from_utf8()
         .read_from(&mut input)
         .unwrap();
-    let render_tree = dom_to_render_tree(dom.document, &mut Discard {}).unwrap();
+    let render_tree = dom_to_render_tree(dom.document.clone(), &mut Discard {}).unwrap();
     RenderTree(render_tree)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1437,25 +1437,13 @@ pub struct RenderedText<D: TextDecorator>(TextRenderer<D>);
 impl<D: TextDecorator> RenderedText<D> {
     /// Convert the rendered HTML document to a string.
     pub fn into_string(self) -> String {
-        self.into()
+        self.0.into_string()
     }
 
     /// Convert the rendered HTML document to a vector of lines with the annotations created by the
     /// decorator.
     pub fn into_lines(self) -> Vec<TaggedLine<Vec<D::Annotation>>> {
-        self.into()
-    }
-}
-
-impl<D: TextDecorator> From<RenderedText<D>> for String {
-    fn from(text: RenderedText<D>) -> String {
-        text.0.into_string()
-    }
-}
-
-impl<D: TextDecorator> From<RenderedText<D>> for Vec<TaggedLine<Vec<D::Annotation>>> {
-    fn from(text: RenderedText<D>) -> Vec<TaggedLine<Vec<D::Annotation>>> {
-        text.0
+        self.0
             .into_lines()
             .into_iter()
             .map(RenderLine::into_tagged_line)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@ impl SizeEstimate {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 /// Render tree table cell
 pub struct RenderTableCell {
     colspan: usize,
@@ -151,7 +151,7 @@ impl RenderTableCell {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 /// Render tree table row
 pub struct RenderTableRow {
     cells: Vec<RenderTableCell>,
@@ -204,7 +204,7 @@ impl RenderTableRow {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 /// A representation of a table render tree with metadata.
 pub struct RenderTable {
     rows: Vec<RenderTableRow>,
@@ -287,7 +287,7 @@ impl RenderTable {
 }
 
 /// The node-specific information distilled from the DOM.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum RenderNodeInfo {
     /// Some text.
     Text(String),
@@ -340,7 +340,7 @@ pub enum RenderNodeInfo {
 }
 
 /// Common fields from a node.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct RenderNode {
     size_estimate: Cell<Option<SizeEstimate>>,
     info: RenderNodeInfo,
@@ -1404,6 +1404,8 @@ fn render_table_cell<T: Write, R: Renderer>(
 /// The structure of an HTML document that can be rendered using a [`TextDecorator`][].
 ///
 /// [`TextDecorator`]: render/text_renderer/trait.TextDecorator.html
+
+#[derive(Clone, Debug)]
 pub struct RenderTree(RenderNode);
 
 impl RenderTree {

--- a/src/render/text_renderer.rs
+++ b/src/render/text_renderer.rs
@@ -6,13 +6,13 @@
 use super::Renderer;
 use std::fmt::Debug;
 use std::mem;
-use std::vec;
 use std::ops::Deref;
+use std::vec;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 /// A wrapper around a String with extra metadata.
-#[derive(Debug)]
-pub struct TaggedString<T: Debug> {
+#[derive(Debug, PartialEq)]
+pub struct TaggedString<T: Debug + PartialEq> {
     /// The wrapped text.
     pub s: String,
 
@@ -22,7 +22,7 @@ pub struct TaggedString<T: Debug> {
 
 /// An element of a line of tagged text: either a TaggedString or a
 /// marker appearing in between document characters.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum TaggedLineElement<T: Debug + Eq + PartialEq + Clone> {
     /// A string with tag information attached.
     Str(TaggedString<T>),
@@ -32,7 +32,7 @@ pub enum TaggedLineElement<T: Debug + Eq + PartialEq + Clone> {
 }
 
 /// A line of tagged text (composed of a set of `TaggedString`s).
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct TaggedLine<T: Debug + Eq + PartialEq + Clone> {
     v: Vec<TaggedLineElement<T>>,
 }


### PR DESCRIPTION
Previously, there were three different entry points for html2text:
from_read, from_read_with_decorator and from_read_rich.  This had two
drawbacks:

Firstly, the user always had to parse and render the HTML at the same
time.  But there are use cases where the user wants to render the same
HTML document using different widths or decorators.  This involved
parsing the document multiple times.

Secondly, it was impossible to create rich text with a custom decorator.
This would have required a new function from_read_rich_with_decorator.

This patch introduces a new entry point for the pubic API, the parse
function.  It reads and parses the HTML document and returns a
RenderTree object.  This object can then be rendered into a RenderedText
object using a custom decorator or the default plain and rich
decorators.  The RendererText object can be converted to a string or to
a vector of annotated lines.

----

Since I brought up the rich text decorator issue (#24), I noticed another problem:  When displaying an HTML document in a terminal user interface using cursive, I have to render the document multiple times during the layout phase and if the terminal size changes.  Currently, I have to parse the document every time I want to render it although it did not change.  This is not very efficient, especially as the HTML parsing seems to be the most expensive step.  This PR attemps to solve both issues.