### PR TITLE
Add tagged_strings method to TaggedLine

### DIFF
--- a/examples/html2term.rs
+++ b/examples/html2term.rs
@@ -96,18 +96,14 @@ mod top {
     }
 
     fn find_links(lines: &Vec<TaggedLine<Vec<RichAnnotation>>>) -> LinkMap {
-        use self::TaggedLineElement::Str;
-
         let mut map = Vec::new();
         for line in lines {
             let mut linevec = Vec::new();
 
-            for tli in line.iter() {
-                if let Str(ts) = tli {
-                    let link = link_from_tag(&ts.tag);
-                    for _ in 0..UnicodeWidthStr::width(ts.s.as_str()) {
-                        linevec.push(link.clone());
-                    }
+            for ts in line.tagged_strings() {
+                let link = link_from_tag(&ts.tag);
+                for _ in 0..UnicodeWidthStr::width(ts.s.as_str()) {
+                    linevec.push(link.clone());
                 }
             }
 
@@ -194,21 +190,17 @@ mod top {
             let vis_y_limit = std::cmp::min(top_y + height, max_y + 1);
             write!(screen, "{}", termion::clear::All).unwrap();
             for (i, line) in annotated[top_y..vis_y_limit].iter().enumerate() {
-                use self::TaggedLineElement::Str;
-
                 write!(screen, "{}", Goto(1, i as u16 + 1)).unwrap();
-                for tli in line.iter() {
-                    if let Str(ts) = tli {
-                        let style = to_style(&ts.tag);
-                        let link = link_from_tag(&ts.tag);
-                        match (opt_url, link) {
-                            (Some(ref t1), Some(ref t2)) if t1 == t2 => {
-                                write!(screen, "{}", termion::style::Invert).unwrap();
-                            }
-                            _ => (),
+                for ts in line.tagged_strings() {
+                    let style = to_style(&ts.tag);
+                    let link = link_from_tag(&ts.tag);
+                    match (opt_url, link) {
+                        (Some(ref t1), Some(ref t2)) if t1 == t2 => {
+                            write!(screen, "{}", termion::style::Invert).unwrap();
                         }
-                        write!(screen, "{}{}{}", style, ts.s, termion::style::Reset).unwrap();
+                        _ => (),
                     }
+                    write!(screen, "{}{}{}", style, ts.s, termion::style::Reset).unwrap();
                 }
             }
 

--- a/src/render/text_renderer.rs
+++ b/src/render/text_renderer.rs
@@ -153,17 +153,17 @@ impl<T: Debug + Eq + PartialEq + Clone + Default> TaggedLine<T> {
         Box::new(self.v.iter())
     }
 
+    /// Iterator over the tagged strings in this line, ignoring any fragments.
+    pub fn tagged_strings(&self) -> impl Iterator<Item = &TaggedString<T>> {
+        self.v.iter().filter_map(|tle| match tle {
+            TaggedLineElement::Str(ts) => Some(ts),
+            _ => None,
+        })
+    }
+
     /// Return the width of the line in cells
     pub fn width(&self) -> usize {
-        use self::TaggedLineElement::Str;
-
-        let mut result = 0;
-        for tle in &self.v {
-            if let Str(ts) = tle {
-                result += UnicodeWidthStr::width(ts.s.as_str());
-            }
-        }
-        result
+        self.tagged_strings().map(|ts| UnicodeWidthStr::width(ts.s.as_str())).sum()
     }
 
     /// Pad this line to width with spaces (or if already at least this wide, do


### PR DESCRIPTION
This patch adds the tagged_strings method to TaggedLine that is a
shorthand for:

    self.iter().filter_map(|tle| match tle {
        TaggedLineElement::Str(ts) => Some(ts),
        _ => None,
    })

Many TaggedLine consumers don’t care about fragments and only want to
iterate over the tagged strings.