### PR TITLE
Fix strikeout tag in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Possible log types:
 
 ### 0.2.0
 
-- [added] Support <s> strikeout text.
+- [added] Support `<s>` strikeout text.
 
 ### 0.1.14 (2020-08-07)
 


### PR DESCRIPTION
Previosuly, half of the rendered text of the changelog was struck out
because of an unescaped and unclosed strikout tag.  This patch fixes the
formatting by wrapping the tag in backticks.