### PR TITLE
Keep annotations in TextRenderer::into_lines

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1041,3 +1041,85 @@ fn test_pre_rich() {
         ]
     );
 }
+
+#[test]
+fn test_finalise() {
+    use crate::render::text_renderer::{TaggedLine, TextDecorator};
+
+    struct TestDecorator;
+
+    impl TextDecorator for TestDecorator {
+        type Annotation = bool;
+
+        fn decorate_link_start(&mut self, _url: &str) -> (String, Self::Annotation) {
+            Default::default()
+        }
+
+        fn decorate_link_end(&mut self) -> String {
+            Default::default()
+        }
+
+        fn decorate_em_start(&mut self) -> (String, Self::Annotation) {
+            Default::default()
+        }
+
+        fn decorate_em_end(&mut self) -> String {
+            Default::default()
+        }
+
+        fn decorate_strong_start(&mut self) -> (String, Self::Annotation) {
+            Default::default()
+        }
+
+        fn decorate_strong_end(&mut self) -> String {
+            Default::default()
+        }
+
+        fn decorate_strikeout_start(&mut self) -> (String, Self::Annotation) {
+            Default::default()
+        }
+
+        fn decorate_strikeout_end(&mut self) -> String {
+            Default::default()
+        }
+
+        fn decorate_code_start(&mut self) -> (String, Self::Annotation) {
+            Default::default()
+        }
+
+        fn decorate_code_end(&mut self) -> String {
+            Default::default()
+        }
+
+        fn decorate_preformat_first(&mut self) -> Self::Annotation {
+            Default::default()
+        }
+
+        fn decorate_preformat_cont(&mut self) -> Self::Annotation {
+            Default::default()
+        }
+
+        fn decorate_image(&mut self, _title: &str) -> (String, Self::Annotation) {
+            Default::default()
+        }
+
+        fn finalise(self) -> Vec<TaggedLine<bool>> {
+            vec![TaggedLine::from_string(String::new(), &true)]
+        }
+
+        fn make_subblock_decorator(&self) -> Self {
+            TestDecorator
+        }
+    }
+
+    assert_eq!(
+        crate::parse("test".as_bytes())
+            .render(80, TestDecorator)
+            .into_lines(),
+        vec![
+            TaggedLine::from_string("test".to_owned(), &Vec::new()),
+            TaggedLine::new(),
+            TaggedLine::from_string("".to_owned(), &vec![true]),
+        ]
+    );
+}


### PR DESCRIPTION
The TextRenderer::into_lines method calls the TextDecorator::finalise
method and appends the returned lines to the rendered lines, re-wrapping
them if required.  Previously, it would concatenate all strings into
lines and append one TaggedString without annotations per line.

With this patch, we keep the original tagged strings and just split them
if required.  This means that the annotations are no longer stripped
from the lines returned by finalise.  We also add a new test case that
checks that these annotations are present.

Fixes #39.