### PR TITLE
Fix issue with small table and usize::MAX width.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,9 @@ jobs:
       - run: cargo --version
       - run: cargo build
       - run: cargo test
-  build-1-49:
+  build-1-56:
     docker:
-      - image: cimg/rust:1.49
+      - image: cimg/rust:1.56
     steps:
       - checkout
       - run: cargo --version
@@ -54,5 +54,5 @@ workflows:
   build:
     jobs:
       - "build-stable"
-      - "build-1-49"
+      - "build-1-56"
       - "build-windows"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/jugglerchris/rust-html2text/"
 readme = "README.md"
 documentation = "https://docs.rs/html2text/"
 edition = "2018"
-rust-version = "1.49"
+rust-version = "1.56"
 
 keywords = ["html", "text"]
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1405,7 +1405,13 @@ fn render_table_tree<T: Write, R: Renderer>(
                     0
                 } else {
                     min(sz.size,
-                        max(sz.size * width / tot_size, sz.min_width))
+                        if usize::MAX/width <= sz.size {
+                            // The provided width is too large to multiply by width,
+                            // so do it the other way around.
+                            max((width / tot_size) * sz.size, sz.min_width)
+                        } else {
+                            max(sz.size * width / tot_size, sz.min_width)
+                        })
                 }
             })
             .collect()

--- a/src/render/text_renderer.rs
+++ b/src/render/text_renderer.rs
@@ -1172,7 +1172,7 @@ impl<D: TextDecorator> Renderer for TextRenderer<D> {
             .map(|&(_, ref v)| v.len())
             .max()
             .unwrap_or(0);
-        let spaces: String = (0..self.width).map(|_| ' ').collect();
+        let spaces: String = (0..tot_width).map(|_| ' ').collect();
         let last_cellno = line_sets.len() - 1;
         for i in 0..cell_height {
             let mut line = TaggedLine::new();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1303,3 +1303,11 @@ der
 ─────
 ", 5);
 }
+
+#[test]
+fn test_max_width() {
+    let html = r#"<table><td><p>3,266</p>"#;
+    let decorator = crate::render::text_renderer::PlainDecorator::new();
+    let text = from_read_with_decorator(html.as_bytes(), usize::MAX, decorator.clone());
+    println!("{}", text);
+}


### PR DESCRIPTION
There were two problems:
* An integer overflow when calculating column widths
* Trying to allocate a string of usize::MAX spaces.

Things should behave a little better with large widths.