### PR TITLE
Preserve empty lines in <pre></pre> blocks

### DIFF
--- a/src/render/text_renderer.rs
+++ b/src/render/text_renderer.rs
@@ -329,11 +329,15 @@ impl<T: Clone + Eq + Debug + Default> WrappedBlock<T> {
 
     fn flush_line(&mut self) {
         if !self.line.is_empty() {
-            let mut tmp_line = TaggedLine::new();
-            mem::swap(&mut tmp_line, &mut self.line);
-            self.text.push(tmp_line);
-            self.linelen = 0;
+            self.force_flush_line();
         }
+    }
+
+    fn force_flush_line(&mut self) {
+        let mut tmp_line = TaggedLine::new();
+        mem::swap(&mut tmp_line, &mut self.line);
+        self.text.push(tmp_line);
+        self.linelen = 0;
     }
 
     fn flush(&mut self) {
@@ -410,7 +414,7 @@ impl<T: Clone + Eq + Debug + Default> WrappedBlock<T> {
             } else {
                 match c {
                     '\n' => {
-                        self.flush_line();
+                        self.force_flush_line();
                         self.pre_wrapped = false;
                     }
                     '\t' => {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1369,3 +1369,16 @@ fn test_max_width() {
     let text = from_read_with_decorator(html.as_bytes(), usize::MAX, decorator.clone());
     println!("{}", text);
 }
+
+#[test]
+fn test_preserving_empty_newlines_in_pre_blocks() {
+    let html = r#"<pre>
+Test.
+
+
+End.
+</pre>"#;
+    let decorator = crate::render::text_renderer::TrivialDecorator::new();
+    let text = from_read_with_decorator(html.as_bytes(), usize::MAX, decorator.clone());
+    assert_eq!(text, "Test.\n\n\nEnd.\n");
+} 


### PR DESCRIPTION
Let me know if you want to change the names of the functions or do something else entirely.