### PR TITLE
Emit img src in RichAnnotation (fixes #72)

### DIFF
--- a/examples/html2term.rs
+++ b/examples/html2term.rs
@@ -30,7 +30,7 @@ mod top {
                 RichAnnotation::Link(_) => {
                     style.push_str(&format!("{}", termion::style::Underline));
                 }
-                RichAnnotation::Image => {
+                RichAnnotation::Image(_) => {
                     style.push_str(&format!(
                         "{}",
                         termion::color::Fg(termion::color::LightBlue)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -992,12 +992,11 @@ fn process_dom_node<'a, 'b, T: Write>(
                             break;
                         }
                     }
-                    return match (title, src) {
-                        (Some(title), Some(src)) => {
-                                Finished(RenderNode::new(Img(src.into(), title.into())))
-                        }
-                        _ => Nothing
-                    };
+                    if let (Some(title), Some(src)) = (title, src) {
+                        Finished(RenderNode::new(Img(src.into(), title.into())))
+                    } else {
+                        Nothing
+                    }
                 }
                 expanded_name!(html "h1")
                 | expanded_name!(html "h2")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,7 +316,7 @@ pub enum RenderNodeInfo {
     /// A code region
     Code(Vec<RenderNode>),
     /// An image (title)
-    Img(String),
+    Img(String, String),
     /// A block element with children
     Block(Vec<RenderNode>),
     /// A header (h1, h2, ...) with children
@@ -380,7 +380,7 @@ impl RenderNode {
 
         // Otherwise, make an estimate.
         let estimate = match self.info {
-            Text(ref t) | Img(ref t) => {
+            Text(ref t) | Img(_, ref t) => {
                 use unicode_width::UnicodeWidthStr;
                 let mut len = t.trim().width();
                 // Add one for preceding whitespace.
@@ -460,7 +460,7 @@ impl RenderNode {
 
         // Otherwise, make an estimate.
         match self.info {
-            Text(ref t) | Img(ref t) => {
+            Text(ref t) | Img(_, ref t) => {
                 let len = t.trim().len();
                 len == 0
             }
@@ -495,7 +495,7 @@ fn precalc_size_estimate<'a>(node: &'a RenderNode) -> TreeMapResult<(), &'a Rend
         return TreeMapResult::Nothing;
     }
     match node.info {
-        Text(_) | Img(_) | Break | FragStart(_) => {
+        Text(_) | Img(_, _) | Break | FragStart(_) => {
             let _ = node.get_size_estimate();
             TreeMapResult::Nothing
         }
@@ -980,17 +980,24 @@ fn process_dom_node<'a, 'b, T: Write>(
                 expanded_name!(html "img") => {
                     let borrowed = attrs.borrow();
                     let mut title = None;
+                    let mut src = None;
                     for attr in borrowed.iter() {
                         if &attr.name.local == "alt" && !attr.value.is_empty() {
                             title = Some(&*attr.value);
+                        }
+                        if &attr.name.local == "src" && !attr.value.is_empty() {
+                            src = Some(&*attr.value);
+                        }
+                        if title.is_some() && src.is_some() {
                             break;
                         }
                     }
-                    if let Some(title) = title {
-                        Finished(RenderNode::new(Img(title.into())))
-                    } else {
-                        Nothing
-                    }
+                    return match (title, src) {
+                        (Some(title), Some(src)) => {
+                                Finished(RenderNode::new(Img(src.into(), title.into())))
+                        }
+                        _ => Nothing
+                    };
                 }
                 expanded_name!(html "h1")
                 | expanded_name!(html "h2")
@@ -1228,8 +1235,8 @@ fn do_render_node<'a, 'b, T: Write, R: Renderer>(
                 Some(None)
             })
         }
-        Img(title) => {
-            builder.add_image(&title);
+        Img(src, title) => {
+            builder.add_image(&src, &title);
             Finished(None)
         }
         Block(children) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,7 +315,7 @@ pub enum RenderNodeInfo {
     Strikeout(Vec<RenderNode>),
     /// A code region
     Code(Vec<RenderNode>),
-    /// An image (title)
+    /// An image (src, title)
     Img(String, String),
     /// A block element with children
     Block(Vec<RenderNode>),

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -109,7 +109,7 @@ pub trait Renderer {
     fn end_code(&mut self);
 
     /// Add an image
-    fn add_image(&mut self, title: &str);
+    fn add_image(&mut self, src: &str, title: &str);
 
     /// Get prefix string of header in specific level.
     fn header_prefix(&mut self, level: usize) -> String;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1138,7 +1138,7 @@ fn test_finalise() {
             Default::default()
         }
 
-        fn decorate_image(&mut self, _title: &str) -> (String, Self::Annotation) {
+        fn decorate_image(&mut self, _src: &str, _title: &str) -> (String, Self::Annotation) {
             Default::default()
         }
 


### PR DESCRIPTION
This PR adds logic to include an img tag's `src` attribute value in the `RichAnnotation::Image` enum that's emitted during decoration.