### PR TITLE
Fix: ignore wrapping for links

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1129,11 +1129,11 @@ fn render_tree_to_string<T: Write, D: TextDecorator>(
         do_render_node(renderer, node, err_out)
     });
     let (mut renderer, links) = renderer.into_inner();
-    let lines = renderer.finalise(links);
+    let linklines = renderer.finalise(links);
     // And add the links
-    if !lines.is_empty() {
+    if !linklines.is_empty() {
         renderer.start_block();
-        renderer.fmt_links(lines);
+        renderer.fmt_links(linklines);
     }
     renderer
 }

--- a/src/render/text_renderer.rs
+++ b/src/render/text_renderer.rs
@@ -891,49 +891,21 @@ impl<D: TextDecorator> SubRenderer<D> {
     }
 
     /// Wrap links to width
-    pub fn fmt_links(&mut self, mut links: Vec<TaggedLine<D::Annotation>>) {
-        for line in links.drain(..) {
-            /* Hard wrap */
-            let mut pos = 0;
-            let mut wrapped_line = TaggedLine::new();
-            for ts in line.into_tagged_strings() {
+    pub fn fmt_links(&mut self, links: Vec<TaggedLine<D::Annotation>>) {
+        for link in links {
+            let mut line = TaggedLine::new();
+            for ts in link.into_tagged_strings() {
                 // FIXME: should we percent-escape?  This is probably
                 // an invalid URL to start with.
                 let s = ts.s.replace('\n', " ");
                 let tag = vec![ts.tag];
 
-                let width = s.width();
-                if pos + width > self.width {
-                    // split the string and start a new line
-                    let mut buf = String::new();
-                    for c in s.chars() {
-                        let c_width = UnicodeWidthChar::width(c).unwrap_or(0);
-                        if pos + c_width > self.width {
-                            if !buf.is_empty() {
-                                wrapped_line.push_str(TaggedString {
-                                    s: buf,
-                                    tag: tag.clone(),
-                                });
-                                buf = String::new();
-                            }
-
-                            self.lines.push_back(RenderLine::Text(wrapped_line));
-                            wrapped_line = TaggedLine::new();
-                            pos = 0;
-                        }
-                        pos += c_width;
-                        buf.push(c);
-                    }
-                    wrapped_line.push_str(TaggedString { s: buf, tag });
-                } else {
-                    wrapped_line.push_str(TaggedString {
-                        s: s.to_owned(),
-                        tag,
-                    });
-                    pos += width;
-                }
+                line.push_str(TaggedString {
+                    s: s.to_owned(),
+                    tag,
+                });
             }
-            self.lines.push_back(RenderLine::Text(wrapped_line));
+            self.lines.push_back(RenderLine::Text(line));
         }
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -450,9 +450,7 @@ fn test_link_wrap() {
        <a href="http://www.example.com/">Hello</a>"#,
         r"[Hello][1]
 
-[1]: http:
-//www.exam
-ple.com/
+[1]: http://www.example.com/
 ",
         10,
     );


### PR DESCRIPTION
Arguably, wrapping links is not particularly helpful. Wrapping to a given width is sensible for elements where html2text must remain in control of the visual appearance, but the links that come after the main content are a block of text where the width to which they are wrapped is not really relevant. Worse, wrapping means off-the-shelf tools which could easily extract all the links from the bottom of the plaintext output no longer work, but must deal with linebreaks inside of links. By turning off wrapping specifically of links, these tools work as expected.