### PR TITLE
Panic when passed a zero width instead of OOM.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1592,6 +1592,9 @@ pub struct RenderTree(RenderNode);
 impl RenderTree {
     /// Render this document using the given `decorator` and wrap it to `width` columns.
     pub fn render<D: TextDecorator>(self, width: usize, decorator: D) -> RenderedText<D> {
+        if width == 0 {
+            panic!("Error: width can not be zero");
+        }
         let builder = SubRenderer::new(width, decorator);
         let builder = render_tree_to_string(builder, self.0, &mut Discard {});
         RenderedText(builder)


### PR DESCRIPTION
Fixes #88.

Perhaps we should move to returning a `Result`, but this at least should stop the OOM and make errors easier to debug.