### PR TITLE
Fix nits in documentation.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1801,7 +1801,7 @@ pub mod config {
         }
 
         #[cfg(feature = "css")]
-        /// Parse CSS from any <style> elements and use supported rules.
+        /// Parse CSS from any \<style\> elements and use supported rules.
         pub fn use_doc_css(mut self) -> Self {
             self.use_doc_css = true;
             self

--- a/src/render/text_renderer.rs
+++ b/src/render/text_renderer.rs
@@ -541,7 +541,9 @@ impl<T: Clone + Eq + Debug + Default> WrappedBlock<T> {
 /// Decorating refers to adding extra text around the rendered version
 /// of some elements, such as surrounding emphasised text with `*` like
 /// in markdown: `Some *bold* text`.  The decorations are formatted and
-/// wrapped along with the rest of the rendered text.  This is
+/// wrapped along with the rest of the rendered text.  This is suitable
+/// for rendering HTML to an environment where terminal attributes are
+/// not available.
 ///
 /// In addition, instances of `TextDecorator` can also return annotations
 /// of an associated type `Annotation` which will be associated with spans of
@@ -568,19 +570,19 @@ pub trait TextDecorator {
     /// Return an annotation and rendering prefix for strong
     fn decorate_strong_start(&mut self) -> (String, Self::Annotation);
 
-    /// Return a suffix for after an strong.
+    /// Return a suffix for after a strong.
     fn decorate_strong_end(&mut self) -> String;
 
     /// Return an annotation and rendering prefix for strikeout
     fn decorate_strikeout_start(&mut self) -> (String, Self::Annotation);
 
-    /// Return a suffix for after an strikeout.
+    /// Return a suffix for after a strikeout.
     fn decorate_strikeout_end(&mut self) -> String;
 
     /// Return an annotation and rendering prefix for code
     fn decorate_code_start(&mut self) -> (String, Self::Annotation);
 
-    /// Return a suffix for after an code.
+    /// Return a suffix for after a code.
     fn decorate_code_end(&mut self) -> String;
 
     /// Return an annotation for the initial part of a preformatted line


### PR DESCRIPTION
The doc comment for use_doc_css had an unescaped <style>, which was emitted unchanged into the HTML by rustdoc and ate the whole of the rest of the HTML output file. I've escaped it so that it's printed literally.

TextDecorator's top-level documentation had a paragraph ending with an unfinished sentence. I've finished it as best I could, although of course I may have guessed wrong!

Several decorator methods had the word 'an' before a consonant. I suspect it was copy-paste error from 'after an em' just above.