### PR TITLE
Simplistic support for <i>, <ins> and <del>.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1154,11 +1154,16 @@ fn process_dom_node<'a, 'b, 'c, T: Write>(
                         postfn: None,
                     }
                 }
-                expanded_name!(html "em") => pending(handle, |_, cs| Ok(Some(RenderNode::new(Em(cs))))),
+                expanded_name!(html "em")
+                | expanded_name!(html "i")
+                | expanded_name!(html "ins") => {
+                    pending(handle, |_, cs| Ok(Some(RenderNode::new(Em(cs)))))
+                }
                 expanded_name!(html "strong") => {
                     pending(handle, |_, cs| Ok(Some(RenderNode::new(Strong(cs)))))
                 }
-                expanded_name!(html "s") => {
+                expanded_name!(html "s")
+                | expanded_name!(html "del") => {
                     pending(handle, |_, cs| Ok(Some(RenderNode::new(Strikeout(cs)))))
                 }
                 expanded_name!(html "code") => {


### PR DESCRIPTION
`<i>` and `<ins>` are treated the same as `<em>`. That seems a bit weird because `<ins>` is canonically shown as underlining whereas `<i>` is canonically italic, so they shouldn't be the same. On the other hand, `<i>` and `<em>` _are_ canonically the same, and underlining is often the most sensible thing to do with `<em>`, so perhaps in this environment it's not totally silly. Anyway, it at least means those two tags aren't completely ignored.

`<del>` is treated the same as `<s>`, for strikeout.