### PR TITLE
Fix an issue which caused the max wrap width not to work.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Possible log types:
 - `[fixed]` for any bug fixes.
 - `[security]` to invite users to upgrade in case of vulnerabilities.
 
+### 0.10.1
+
+- [fixed] `max_width` was not working with some render methods.
+
 ### 0.10.0
 
 - [added] Simple support for `<i>`, `<ins>`, and `<del>` (thanks sgtatham)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "html2text"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Chris Emerson <github@mail.nosreme.org>"]
 description = "Render HTML as plain text."
 repository = "https://github.com/jugglerchris/rust-html2text/"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1941,7 +1941,7 @@ pub mod config {
         pub fn lines_from_read<R: std::io::Read>(mut self, input: R, width: usize) -> Result<Vec<TaggedLine<Vec<D::Annotation>>>> {
             let mut context = self.make_context();
             Ok(self.do_parse(&mut context, input)?
-                .render(width, self.decorator)?
+                .render_with_context(&mut context, width, self.decorator)?
                 .into_lines()?)
         }
 
@@ -1994,7 +1994,7 @@ pub mod config {
 
             let mut context = self.make_context();
             let lines = self.do_parse(&mut context, input)?
-                .render(width, self.decorator)?
+                .render_with_context(&mut context, width, self.decorator)?
                 .into_lines()?;
 
             let mut result = String::new();


### PR DESCRIPTION
Some of the Config methods weren't passing the context to the renderer.