### PR TITLE
Mark RcDom as pub.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,8 +81,8 @@ mod markup5ever_rcdom;
 use markup5ever_rcdom::{
     Handle,
     NodeData::{Comment, Document, Element},
-    RcDom,
 };
+pub use markup5ever_rcdom::RcDom;
 use std::cell::Cell;
 use std::cmp::{max, min};
 


### PR DESCRIPTION
It was already being returned from some functions, and is pub, but crate::RcDom wasn't pub.