### PR TITLE
CSS: handle color/bgcolor attributes.

### DIFF
--- a/src/css.rs
+++ b/src/css.rs
@@ -5,7 +5,7 @@ use std::ops::Deref;
 
 use lightningcss::{stylesheet::{
     ParserOptions, StyleSheet, StyleAttribute
-}, rules::CssRule, properties::{Property, display::{self, DisplayKeyword}}, values::color::CssColor, declaration::DeclarationBlock};
+}, rules::CssRule, properties::{Property, display::{self, DisplayKeyword}}, values::color::CssColor, declaration::DeclarationBlock, traits::Parse};
 
 use crate::{Result, TreeMapResult, markup5ever_rcdom::{Handle, NodeData::{Comment, Document, Element, self}}, tree_map_reduce};
 
@@ -294,7 +294,14 @@ impl StyleData {
                     if &attr.name.local == "style" {
                         let rules = parse_style_attribute(&attr.value).unwrap_or_default();
                         result.extend(rules);
-                        break;
+                    } else if &*attr.name.local == "color" {
+                        if let Ok(colour) = CssColor::parse_string(&*attr.value) {
+                            result.push(Style::Colour(colour));
+                        }
+                    } else if &*attr.name.local == "bgcolor" {
+                        if let Ok(colour) = CssColor::parse_string(&*attr.value) {
+                            result.push(Style::BgColour(colour));
+                        }
                     }
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1236,27 +1236,6 @@ fn process_dom_node<'a, 'b, 'c, T: Write>(
                     /* process children, but don't add anything */
                     pending_noempty(handle, |_, cs| Ok(Some(RenderNode::new(Container(cs)))))
                 }
-                #[cfg(feature = "css")]
-                expanded_name!(html "font") => {
-                    let mut colour = None;
-                    if context.use_doc_css {
-                        use lightningcss::traits::Parse;
-                        let borrowed = attrs.borrow();
-                        for attr in borrowed.iter() {
-                            if &attr.name.local == "color" {
-                                colour = CssColor::parse_string(&*attr.value)
-                                    .ok()
-                                    .and_then(|c| TryFrom::try_from(&c).ok());
-                                break;
-                            }
-                        }
-                    }
-                    if let Some(colour) = colour {
-                        pending_noempty(handle, move |_, cs| Ok(Some(RenderNode::new(Coloured(colour, vec![RenderNode::new(Container(cs))])))))
-                    } else {
-                        pending_noempty(handle, |_, cs| Ok(Some(RenderNode::new(Container(cs)))))
-                    }
-                }
                 expanded_name!(html "a") => {
                     let borrowed = attrs.borrow();
                     let mut target = None;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2044,6 +2044,16 @@ There
     }
 
     #[test]
+    fn test_color_attr()
+    {
+        test_html_coloured(br##"
+        <p>Test <font color="red">red</font></p>
+        "##,
+        r#"Test <R>red</R>
+"#, 20);
+    }
+
+    #[test]
     fn test_css_lists()
     {
         test_html_coloured(br##"


### PR DESCRIPTION
These aren't very standard but are used in the wild. The specific case for <font color="..."> has been removed.