### PR TITLE
Raw extract

### DIFF
--- a/examples/html2term.rs
+++ b/examples/html2term.rs
@@ -78,26 +78,26 @@ mod top {
 
     impl LinkMap {
         pub fn link_at(&self, x: usize, y: usize) -> Option<&str> {
-            if let Some(ref linevec) = self.lines.get(y) {
-                if let Some(&Some(ref text)) = linevec.get(x) {
-                    return Some(&text);
+            if let Some(linevec) = self.lines.get(y) {
+                if let Some(Some(text)) = linevec.get(x) {
+                    return Some(text);
                 }
             }
             None
         }
     }
 
-    fn link_from_tag(tag: &Vec<RichAnnotation>) -> Option<String> {
+    fn link_from_tag(tag: &[RichAnnotation]) -> Option<String> {
         let mut link = None;
         for annotation in tag {
-            if let RichAnnotation::Link(ref text) = *annotation {
+            if let RichAnnotation::Link(text) = annotation {
                 link = Some(text.clone());
             }
         }
         link
     }
 
-    fn find_links(lines: &Vec<TaggedLine<Vec<RichAnnotation>>>) -> LinkMap {
+    fn find_links(lines: &[TaggedLine<Vec<RichAnnotation>>]) -> LinkMap {
         let mut map = Vec::new();
         for line in lines {
             let mut linevec = Vec::new();
@@ -118,12 +118,11 @@ mod top {
         start_xy: HashMap<String, (usize, usize)>,
     }
 
-    fn find_frags(lines: &Vec<TaggedLine<Vec<RichAnnotation>>>) -> FragMap {
+    fn find_frags(lines: &[TaggedLine<Vec<RichAnnotation>>]) -> FragMap {
         use self::TaggedLineElement::*;
 
         let mut map = HashMap::new();
-        let mut y = 0;
-        for line in lines {
+        for (y, line) in lines.iter().enumerate() {
             let mut x = 0;
             for tli in line.iter() {
                 match tli {
@@ -135,7 +134,6 @@ mod top {
                     }
                 }
             }
-            y += 1;
         }
         FragMap { start_xy: map }
     }
@@ -153,7 +151,7 @@ mod top {
         let (width, height) = (width as usize, height as usize);
 
         let mut file = std::fs::File::open(filename).expect("Tried to open file");
-        let annotated = html2text::from_read_rich(&mut file, width as usize);
+        let annotated = html2text::from_read_rich(&mut file, width);
 
         let link_map = find_links(&annotated);
         let frag_map = find_frags(&annotated);
@@ -225,14 +223,10 @@ mod top {
                         }
                     }
                     Key::Char('k') | Key::Up => {
-                        if doc_y > 0 {
-                            doc_y -= 1;
-                        }
+                        doc_y = doc_y.saturating_sub(1);
                     }
                     Key::Char('h') | Key::Left => {
-                        if doc_x > 0 {
-                            doc_x -= 1;
-                        }
+                        doc_x = doc_x.saturating_sub(1);
                     }
                     Key::Char('l') | Key::Right => {
                         if doc_x + 1 < width {
@@ -268,8 +262,8 @@ mod top {
                     Key::Char('\t') => {}
                     Key::Char('\r') | Key::Char('\n') => {
                         if let Some(url) = opt_url {
-                            if url.starts_with("#") {
-                                let start = frag_map.start_xy.get(&url[1..]);
+                            if let Some(u) = url.strip_prefix('#') {
+                                let start = frag_map.start_xy.get(u);
                                 if let Some((x, y)) = start {
                                     doc_x = *x;
                                     doc_y = *y;

--- a/examples/html2text.rs
+++ b/examples/html2text.rs
@@ -1,11 +1,11 @@
 extern crate argparse;
 extern crate html2text;
 use argparse::{ArgumentParser, Store, StoreOption, StoreTrue};
-use html2text::config::{Config, self};
+use html2text::config::{self, Config};
 use html2text::render::text_renderer::{TextDecorator, TrivialDecorator};
+use log::trace;
 use std::io;
 use std::io::Write;
-use log::trace;
 
 #[cfg(unix)]
 use html2text::render::text_renderer::RichAnnotation;
@@ -105,20 +105,19 @@ where
         if flags.use_colour {
             let conf = config::rich();
             let conf = update_config(conf, &flags);
-            return conf.coloured(input, flags.width, default_colour_map)
-                    .unwrap()
+            return conf
+                .coloured(input, flags.width, default_colour_map)
+                .unwrap();
         }
     }
     if literal {
         let conf = config::with_decorator(TrivialDecorator::new());
         let conf = update_config(conf, &flags);
-        conf.string_from_read(input, flags.width)
-            .unwrap()
+        conf.string_from_read(input, flags.width).unwrap()
     } else {
         let conf = config::plain();
         let conf = update_config(conf, &flags);
-        conf.string_from_read(input, flags.width)
-            .unwrap()
+        conf.string_from_read(input, flags.width).unwrap()
     }
 }
 
@@ -174,8 +173,11 @@ fn main() {
             "Output only literal text (no decorations)",
         );
         #[cfg(unix)]
-        ap.refer(&mut flags.use_colour)
-            .add_option(&["--colour"], StoreTrue, "Use ANSI terminal colours");
+        ap.refer(&mut flags.use_colour).add_option(
+            &["--colour"],
+            StoreTrue,
+            "Use ANSI terminal colours",
+        );
         #[cfg(feature = "css")]
         ap.refer(&mut flags.use_css)
             .add_option(&["--css"], StoreTrue, "Enable CSS");

--- a/examples/html2text.rs
+++ b/examples/html2text.rs
@@ -9,8 +9,6 @@ use std::io::Write;
 
 #[cfg(unix)]
 use html2text::render::text_renderer::RichAnnotation;
-#[cfg(unix)]
-use termion;
 
 #[cfg(unix)]
 fn default_colour_map(annotations: &[RichAnnotation], s: &str) -> String {
@@ -187,8 +185,7 @@ fn main() {
     let data = match infile {
         None => {
             let stdin = io::stdin();
-            let data = translate(&mut stdin.lock(), flags, literal);
-            data
+            translate(&mut stdin.lock(), flags, literal)
         }
         Some(name) => {
             let mut file = std::fs::File::open(name).expect("Tried to open file");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1160,18 +1160,17 @@ fn prepend_marker(prefix: RenderNode, mut orig: RenderNode) -> RenderNode {
         TableRow(ref mut rrow, _) => {
             // If the row is empty, then there isn't really anything
             // to attach the fragment start to.
-            if !rrow.cells.is_empty() {
-                rrow.cells[0].content.insert(0, prefix);
+            if let Some(cell) = rrow.cells.get_mut(0) {
+                cell.content.insert(0, prefix);
             }
         }
 
         TableBody(ref mut rows) | Table(RenderTable { ref mut rows, .. }) => {
             // If the row is empty, then there isn't really anything
             // to attach the fragment start to.
-            if !rows.is_empty() {
-                let rrow = &mut rows[0];
-                if !rrow.cells.is_empty() {
-                    rrow.cells[0].content.insert(0, prefix);
+            if let Some(rrow) = rows.get_mut(0) {
+                if let Some(cell) = rrow.cells.get_mut(0) {
+                    cell.content.insert(0, prefix);
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,13 +63,13 @@ extern crate unicode_width;
 #[macro_use]
 mod macros;
 
-pub mod render;
 #[cfg(feature = "css")]
 pub mod css;
+pub mod render;
 
 use render::text_renderer::{
-    PlainDecorator, RenderLine, RichAnnotation, RichDecorator, SubRenderer, TaggedLine, RenderOptions,
-    TextDecorator, TextRenderer,
+    PlainDecorator, RenderLine, RenderOptions, RichAnnotation, RichDecorator, SubRenderer,
+    TaggedLine, TextDecorator, TextRenderer,
 };
 use render::Renderer;
 
@@ -78,14 +78,14 @@ use html5ever::parse_document;
 use html5ever::tendril::TendrilSink;
 use html5ever::tree_builder::TreeBuilderOpts;
 mod markup5ever_rcdom;
+pub use markup5ever_rcdom::RcDom;
 use markup5ever_rcdom::{
     Handle,
     NodeData::{Comment, Document, Element},
 };
-pub use markup5ever_rcdom::RcDom;
-use unicode_width::UnicodeWidthStr;
 use std::cell::Cell;
 use std::cmp::{max, min};
+use unicode_width::UnicodeWidthStr;
 
 #[cfg(feature = "css")]
 use lightningcss::values::color::CssColor;
@@ -115,13 +115,11 @@ impl TryFrom<&CssColor> for Colour {
 
     fn try_from(value: &CssColor) -> std::result::Result<Self, Self::Error> {
         match value {
-            CssColor::RGBA(rgba) => {
-                Ok(Colour {
-                    r: rgba.red,
-                    g: rgba.green,
-                    b: rgba.blue,
-                })
-            }
+            CssColor::RGBA(rgba) => Ok(Colour {
+                r: rgba.red,
+                g: rgba.green,
+                b: rgba.blue,
+            }),
             _ => Err(()),
         }
     }
@@ -392,9 +390,12 @@ impl RenderTable {
         }
         let size = sizes.iter().map(|s| s.size).sum(); // Include borders?
         let min_width = sizes.iter().map(|s| s.min_width).sum::<usize>() + self.num_columns - 1;
-        let result = SizeEstimate { size, min_width, prefix_size: 0 };
-        self.size_estimate
-            .set(Some(result));
+        let result = SizeEstimate {
+            size,
+            min_width,
+            prefix_size: 0,
+        };
+        self.size_estimate.set(Some(result));
         result
     }
 
@@ -490,7 +491,11 @@ impl RenderNode {
     }
 
     /// Calculate the size of this node.
-    fn calc_size_estimate<D: TextDecorator>(&self, context: &HtmlContext, decorator: &'_ D) -> SizeEstimate {
+    fn calc_size_estimate<D: TextDecorator>(
+        &self,
+        context: &HtmlContext,
+        decorator: &'_ D,
+    ) -> SizeEstimate {
         // If it's already calculated, then just return the answer.
         if let Some(s) = self.size_estimate.get() {
             return s;
@@ -532,8 +537,8 @@ impl RenderNode {
             }
 
             Container(ref v) | Em(ref v) | Strong(ref v) | Strikeout(ref v) | Code(ref v)
-            | Block(ref v) | Div(ref v) | Pre(ref v) | Dl(ref v)
-            | Dt(ref v) | ListItem(ref v) | Sup(ref v) => v
+            | Block(ref v) | Div(ref v) | Pre(ref v) | Dl(ref v) | Dt(ref v) | ListItem(ref v)
+            | Sup(ref v) => v
                 .iter()
                 .map(recurse)
                 .fold(Default::default(), SizeEstimate::add),
@@ -546,9 +551,7 @@ impl RenderNode {
                     min_width: 5,
                     prefix_size: 0,
                 }),
-            Dd(ref v) |
-            BlockQuote(ref v) | 
-            Ul(ref v) => {
+            Dd(ref v) | BlockQuote(ref v) | Ul(ref v) => {
                 let prefix = match self.info {
                     Dd(_) => "  ".into(),
                     BlockQuote(_) => decorator.quote_prefix(),
@@ -556,43 +559,43 @@ impl RenderNode {
                     _ => unreachable!(),
                 };
                 let prefix_width = UnicodeWidthStr::width(prefix.as_str());
-                let mut size =
-                    v.iter()
-                     .map(recurse)
-                     .fold(Default::default(), SizeEstimate::add)
-                     .add_hor(SizeEstimate {
-                         size: prefix_width,
-                         min_width: prefix_width,
-                         prefix_size: 0,
-                     });
+                let mut size = v
+                    .iter()
+                    .map(recurse)
+                    .fold(Default::default(), SizeEstimate::add)
+                    .add_hor(SizeEstimate {
+                        size: prefix_width,
+                        min_width: prefix_width,
+                        prefix_size: 0,
+                    });
                 size.prefix_size = prefix_width;
                 size
             }
             Ol(i, ref v) => {
                 let prefix_size = calc_ol_prefix_size(i, v.len(), decorator);
-                let mut result =
-                    v.iter()
-                     .map(recurse)
-                     .fold(Default::default(), SizeEstimate::add)
-                     .add_hor(SizeEstimate {
-                         size: prefix_size,
-                         min_width: prefix_size,
-                         prefix_size: 0,
-                     });
+                let mut result = v
+                    .iter()
+                    .map(recurse)
+                    .fold(Default::default(), SizeEstimate::add)
+                    .add_hor(SizeEstimate {
+                        size: prefix_size,
+                        min_width: prefix_size,
+                        prefix_size: 0,
+                    });
                 result.prefix_size = prefix_size;
                 result
             }
             Header(level, ref v) => {
                 let prefix_size = decorator.header_prefix(level).len();
-                let mut size =
-                    v.iter()
-                     .map(recurse)
-                     .fold(Default::default(), SizeEstimate::add)
-                     .add_hor(SizeEstimate {
-                         size: prefix_size,
-                         min_width: prefix_size,
-                         prefix_size: 0,
-                     });
+                let mut size = v
+                    .iter()
+                    .map(recurse)
+                    .fold(Default::default(), SizeEstimate::add)
+                    .add_hor(SizeEstimate {
+                        size: prefix_size,
+                        min_width: prefix_size,
+                        prefix_size: 0,
+                    });
                 size.prefix_size = prefix_size;
                 size
             }
@@ -604,8 +607,7 @@ impl RenderNode {
             Table(ref t) => t.calc_size_estimate(context),
             TableRow(..) | TableBody(_) | TableCell(_) => unimplemented!(),
             FragStart(_) => Default::default(),
-            BgColoured(_, ref v) |
-            Coloured(_, ref v) => v
+            BgColoured(_, ref v) | Coloured(_, ref v) => v
                 .iter()
                 .map(recurse)
                 .fold(Default::default(), SizeEstimate::add),
@@ -649,16 +651,16 @@ impl RenderNode {
             Table(ref _t) => false,
             TableRow(..) | TableBody(_) | TableCell(_) => false,
             FragStart(_) => true,
-            BgColoured(_, ref v) |
-            Coloured(_, ref v) => v.is_empty(),
+            BgColoured(_, ref v) | Coloured(_, ref v) => v.is_empty(),
         }
     }
 }
 
-fn precalc_size_estimate<'a, 'b: 'a, D: TextDecorator>(node: &'a RenderNode,
-                             context: &mut HtmlContext,
-                             decorator: &'b D,
-                             ) -> Result<TreeMapResult<'a, HtmlContext, &'a RenderNode, ()>> {
+fn precalc_size_estimate<'a, 'b: 'a, D: TextDecorator>(
+    node: &'a RenderNode,
+    context: &mut HtmlContext,
+    decorator: &'b D,
+) -> Result<TreeMapResult<'a, HtmlContext, &'a RenderNode, ()>> {
     use RenderNodeInfo::*;
     if node.size_estimate.get().is_some() {
         return Ok(TreeMapResult::Nothing);
@@ -714,8 +716,7 @@ fn precalc_size_estimate<'a, 'b: 'a, D: TextDecorator>(node: &'a RenderNode,
             }
         }
         TableRow(..) | TableBody(_) | TableCell(_) => unimplemented!(),
-        BgColoured(_, ref v) |
-        Coloured(_, ref v) => TreeMapResult::PendingChildren {
+        BgColoured(_, ref v) | Coloured(_, ref v) => TreeMapResult::PendingChildren {
             children: v.iter().collect(),
             cons: Box::new(move |context, _cs| {
                 node.calc_size_estimate(context, decorator);
@@ -728,7 +729,11 @@ fn precalc_size_estimate<'a, 'b: 'a, D: TextDecorator>(node: &'a RenderNode,
 }
 
 /// Make a Vec of RenderNodes from the children of a node.
-fn children_to_render_nodes<T: Write>(handle: Handle, err_out: &mut T, context: &mut HtmlContext) -> Result<Vec<RenderNode>> {
+fn children_to_render_nodes<T: Write>(
+    handle: Handle,
+    err_out: &mut T,
+    context: &mut HtmlContext,
+) -> Result<Vec<RenderNode>> {
     /* process children, but don't add anything */
     handle
         .children
@@ -785,8 +790,9 @@ fn table_to_render_tree<'a, 'b, T: Write>(
         if rows.is_empty() {
             Ok(None)
         } else {
-            Ok(Some(RenderNode::new(RenderNodeInfo::Table(RenderTable::new(
-                                rows)))))
+            Ok(Some(RenderNode::new(RenderNodeInfo::Table(
+                RenderTable::new(rows),
+            ))))
         }
     })
 }
@@ -811,17 +817,15 @@ fn tbody_to_render_tree<'a, 'b, T: Write>(
 
         // Handle colspan=0 by replacing it.
         // Get a list of (has_zero_colspan, sum_colspan)
-        let num_columns =
-            rows.iter()
-                .map(|row| {
-                    row.cells()
-                       // Treat the column as having colspan 1 for initial counting.
-                       .map(|cell| (cell.colspan == 0, cell.colspan.max(1)))
-                       .fold((false, 0), |a, b| {
-                           (a.0 || b.0, a.1 + b.1)
-                       })
-                })
-                .collect::<Vec<_>>();
+        let num_columns = rows
+            .iter()
+            .map(|row| {
+                row.cells()
+                    // Treat the column as having colspan 1 for initial counting.
+                    .map(|cell| (cell.colspan == 0, cell.colspan.max(1)))
+                    .fold((false, 0), |a, b| (a.0 || b.0, a.1 + b.1))
+            })
+            .collect::<Vec<_>>();
 
         let max_columns = num_columns.iter().map(|(_, span)| span).max().unwrap_or(&1);
 
@@ -926,49 +930,54 @@ enum TreeMapResult<'a, C, N, R> {
 
 impl<'a, C: 'a, N> TreeMapResult<'a, C, N, RenderNode> {
     #[cfg(feature = "css")]
-    fn wrap_render_nodes<F>(self, f: F)
-    -> Self 
+    fn wrap_render_nodes<F>(self, f: F) -> Self
     where
-        F: Fn(Vec<RenderNode>) -> RenderNodeInfo + 'a
+        F: Fn(Vec<RenderNode>) -> RenderNodeInfo + 'a,
     {
         use TreeMapResult::*;
         match self {
             Finished(node) => Finished(RenderNode::new(f(vec![node]))),
-            PendingChildren { children, cons, prefn, postfn } => {
+            PendingChildren {
+                children,
+                cons,
+                prefn,
+                postfn,
+            } => {
                 PendingChildren {
                     children,
                     prefn,
                     postfn,
                     cons: Box::new(move |ctx, ch| {
-                        Ok(cons(ctx, ch)?
-                           .map(|n| {
-                               // Special case: lists need to recognise ListItem nodes as
-                               // direct children.
-                               match n.info {
-                                   RenderNodeInfo::ListItem(children) => {
-                                       let wrapped = RenderNode::new(f(children));
-                                       RenderNode::new(
-                                           RenderNodeInfo::ListItem(vec![wrapped]))
-                                   }
-                                   RenderNodeInfo::TableCell(mut cellinfo) => {
-                                       let children = cellinfo.content;
-                                       let wrapped = RenderNode::new(f(children));
-                                       cellinfo.content = vec![wrapped];
-                                       RenderNode::new(
-                                           RenderNodeInfo::TableCell(cellinfo))
-                                   }
-                                   ni => RenderNode::new(f(vec![RenderNode::new(ni)])),
-                               }
-                           }))
+                        Ok(cons(ctx, ch)?.map(|n| {
+                            // Special case: lists need to recognise ListItem nodes as
+                            // direct children.
+                            match n.info {
+                                RenderNodeInfo::ListItem(children) => {
+                                    let wrapped = RenderNode::new(f(children));
+                                    RenderNode::new(RenderNodeInfo::ListItem(vec![wrapped]))
+                                }
+                                RenderNodeInfo::TableCell(mut cellinfo) => {
+                                    let children = cellinfo.content;
+                                    let wrapped = RenderNode::new(f(children));
+                                    cellinfo.content = vec![wrapped];
+                                    RenderNode::new(RenderNodeInfo::TableCell(cellinfo))
+                                }
+                                ni => RenderNode::new(f(vec![RenderNode::new(ni)])),
+                            }
+                        }))
                     }),
                 }
             }
-            Nothing => Nothing
+            Nothing => Nothing,
         }
     }
 }
 
-fn tree_map_reduce<'a, C, N, R, M>(context: &mut C, top: N, mut process_node: M) -> Result<Option<R>>
+fn tree_map_reduce<'a, C, N, R, M>(
+    context: &mut C,
+    top: N,
+    mut process_node: M,
+) -> Result<Option<R>>
 where
     M: for<'c> FnMut(&'c mut C, N) -> Result<TreeMapResult<'a, C, N, R>>,
 {
@@ -1070,8 +1079,8 @@ struct HtmlContext {
 fn dom_to_render_tree_with_context<T: Write>(
     handle: Handle,
     err_out: &mut T,
-    context: &mut HtmlContext)
--> Result<Option<RenderNode>> {
+    context: &mut HtmlContext,
+) -> Result<Option<RenderNode>> {
     html_trace!("### dom_to_render_tree: HTML: {:?}", handle);
     #[cfg(feature = "css")]
     if context.use_doc_css {
@@ -1095,7 +1104,8 @@ pub fn dom_to_render_tree<T: Write>(handle: Handle, err_out: &mut T) -> Result<O
 
 fn pending<'a, F>(handle: Handle, f: F) -> TreeMapResult<'a, HtmlContext, Handle, RenderNode>
 where
-    for<'r> F: Fn(&'r mut HtmlContext, std::vec::Vec<RenderNode>) -> Result<Option<RenderNode>> + 'static,
+    for<'r> F:
+        Fn(&'r mut HtmlContext, std::vec::Vec<RenderNode>) -> Result<Option<RenderNode>> + 'static,
 {
     TreeMapResult::PendingChildren {
         children: handle.children.borrow().clone(),
@@ -1105,9 +1115,13 @@ where
     }
 }
 
-fn pending_noempty<'a, F>(handle: Handle, f: F) -> TreeMapResult<'a, HtmlContext, Handle, RenderNode>
+fn pending_noempty<'a, F>(
+    handle: Handle,
+    f: F,
+) -> TreeMapResult<'a, HtmlContext, Handle, RenderNode>
 where
-    for<'r> F: Fn(&'r mut HtmlContext, std::vec::Vec<RenderNode>) -> Result<Option<RenderNode>> + 'static,
+    for<'r> F:
+        Fn(&'r mut HtmlContext, std::vec::Vec<RenderNode>) -> Result<Option<RenderNode>> + 'static,
 {
     TreeMapResult::PendingChildren {
         children: handle.children.borrow().clone(),
@@ -1195,7 +1209,9 @@ fn process_dom_node<'a, 'b, 'c, T: Write>(
     use TreeMapResult::*;
 
     Ok(match handle.clone().data {
-        Document => pending(handle, |_context, cs| Ok(Some(RenderNode::new(Container(cs))))),
+        Document => pending(handle, |_context, cs| {
+            Ok(Some(RenderNode::new(Container(cs))))
+        }),
         Comment { .. } => Nothing,
         Element {
             ref name,
@@ -1210,7 +1226,10 @@ fn process_dom_node<'a, 'b, 'c, T: Write>(
             let mut css_bgcolour = None;
             #[cfg(feature = "css")]
             {
-                for style in context.style_data.matching_rules(&handle, context.use_doc_css) {
+                for style in context
+                    .style_data
+                    .matching_rules(&handle, context.use_doc_css)
+                {
                     match style {
                         css::Style::Colour(col) => {
                             if let Ok(colour) = Colour::try_from(&col) {
@@ -1229,8 +1248,7 @@ fn process_dom_node<'a, 'b, 'c, T: Write>(
                 }
             };
             let result = match name.expanded() {
-                expanded_name!(html "html")
-                | expanded_name!(html "body") => {
+                expanded_name!(html "html") | expanded_name!(html "body") => {
                     /* process children, but don't add anything */
                     pending(handle, |_, cs| Ok(Some(RenderNode::new(Container(cs)))))
                 }
@@ -1283,8 +1301,7 @@ fn process_dom_node<'a, 'b, 'c, T: Write>(
                 expanded_name!(html "strong") => {
                     pending(handle, |_, cs| Ok(Some(RenderNode::new(Strong(cs)))))
                 }
-                expanded_name!(html "s")
-                | expanded_name!(html "del") => {
+                expanded_name!(html "s") | expanded_name!(html "del") => {
                     pending(handle, |_, cs| Ok(Some(RenderNode::new(Strikeout(cs)))))
                 }
                 expanded_name!(html "code") => {
@@ -1361,7 +1378,8 @@ fn process_dom_node<'a, 'b, 'c, T: Write>(
                     }
 
                     pending_noempty(handle, move |_, cs| {
-                        let cs = cs.into_iter()
+                        let cs = cs
+                            .into_iter()
                             .filter(|n| match &n.info {
                                 RenderNodeInfo::ListItem(..) => true,
                                 _ => false,
@@ -1369,7 +1387,6 @@ fn process_dom_node<'a, 'b, 'c, T: Write>(
                             .collect();
                         Ok(Some(RenderNode::new(Ol(start, cs))))
                     })
-
                 }
                 expanded_name!(html "dl") => Finished(RenderNode::new(Dl(
                     desc_list_children_to_render_nodes(handle.clone(), err_out, context)?,
@@ -1457,7 +1474,9 @@ fn render_tree_to_string<T: Write, D: TextDecorator>(
     err_out: &mut T,
 ) -> Result<SubRenderer<D>> {
     /* Phase 1: get size estimates. */
-    tree_map_reduce(context, &tree, |context, node| precalc_size_estimate(&node, context, decorator))?;
+    tree_map_reduce(context, &tree, |context, node| {
+        precalc_size_estimate(&node, context, decorator)
+    })?;
     /* Phase 2: actually render. */
     let mut renderer = TextRenderer::new(renderer);
     tree_map_reduce(&mut renderer, tree, |renderer, node| {
@@ -1476,7 +1495,10 @@ fn render_tree_to_string<T: Write, D: TextDecorator>(
 fn pending2<
     'a,
     D: TextDecorator,
-    F: Fn(&mut TextRenderer<D>, Vec<Option<SubRenderer<D>>>) -> Result<Option<Option<SubRenderer<D>>>>
+    F: Fn(
+            &mut TextRenderer<D>,
+            Vec<Option<SubRenderer<D>>>,
+        ) -> Result<Option<Option<SubRenderer<D>>>>
         + 'static,
 >(
     children: Vec<RenderNode>,
@@ -1559,7 +1581,8 @@ fn do_render_node<'a, 'b, T: Write, D: TextDecorator>(
             debug_assert!(prefix.len() == prefix_size);
             let min_width = size_estimate.min_width;
             let inner_width = min_width.saturating_sub(prefix_size);
-            let sub_builder = renderer.new_sub_renderer(renderer.width_minus(prefix_size, inner_width)?)?;
+            let sub_builder =
+                renderer.new_sub_renderer(renderer.width_minus(prefix_size, inner_width)?)?;
             renderer.push(sub_builder);
             pending2(children, move |renderer: &mut TextRenderer<D>, _| {
                 let sub_builder = renderer.pop();
@@ -1590,7 +1613,8 @@ fn do_render_node<'a, 'b, T: Write, D: TextDecorator>(
             let prefix = renderer.quote_prefix();
             debug_assert!(size_estimate.prefix_size == prefix.len());
             let inner_width = size_estimate.min_width - prefix.len();
-            let sub_builder = renderer.new_sub_renderer(renderer.width_minus(prefix.len(), inner_width)?)?;
+            let sub_builder =
+                renderer.new_sub_renderer(renderer.width_minus(prefix.len(), inner_width)?)?;
             renderer.push(sub_builder);
             pending2(children, move |renderer: &mut TextRenderer<D>, _| {
                 let sub_builder = renderer.pop();
@@ -1612,7 +1636,8 @@ fn do_render_node<'a, 'b, T: Write, D: TextDecorator>(
                 cons: Box::new(|_, _| Ok(Some(None))),
                 prefn: Some(Box::new(move |renderer: &mut TextRenderer<D>, _| {
                     let inner_width = size_estimate.min_width - prefix_len;
-                    let sub_builder = renderer.new_sub_renderer(renderer.width_minus(prefix_len, inner_width)?)?;
+                    let sub_builder = renderer
+                        .new_sub_renderer(renderer.width_minus(prefix_len, inner_width)?)?;
                     renderer.push(sub_builder);
                     Ok(())
                 })),
@@ -1649,7 +1674,8 @@ fn do_render_node<'a, 'b, T: Write, D: TextDecorator>(
                 cons: Box::new(|_, _| Ok(Some(None))),
                 prefn: Some(Box::new(move |renderer: &mut TextRenderer<D>, _| {
                     let inner_min = size_estimate.min_width - size_estimate.prefix_size;
-                    let sub_builder = renderer.new_sub_renderer(renderer.width_minus(prefix_width, inner_min)?)?;
+                    let sub_builder = renderer
+                        .new_sub_renderer(renderer.width_minus(prefix_width, inner_min)?)?;
                     renderer.push(sub_builder);
                     Ok(())
                 })),
@@ -1732,13 +1758,13 @@ fn do_render_node<'a, 'b, T: Write, D: TextDecorator>(
                 if let Text(s) = &children[0].info {
                     if s.chars().all(|d| d.is_ascii_digit()) {
                         // It's just a string of digits - replace by superscript characters.
-                        const SUPERSCRIPTS: [char; 10] = [
-                            '⁰', '¹', '²', '³', '⁴', '⁵', '⁶', '⁷', '⁸', '⁹'
-                        ];
+                        const SUPERSCRIPTS: [char; 10] =
+                            ['⁰', '¹', '²', '³', '⁴', '⁵', '⁶', '⁷', '⁸', '⁹'];
                         return Some(
                             s.bytes()
-                             .map(|b| SUPERSCRIPTS[(b - b'0') as usize])
-                             .collect())
+                                .map(|b| SUPERSCRIPTS[(b - b'0') as usize])
+                                .collect(),
+                        );
                     }
                 }
                 None
@@ -1863,8 +1889,8 @@ fn render_table_tree<T: Write, D: TextDecorator>(
     Ok(TreeMapResult::PendingChildren {
         children: table.into_rows(col_widths, vert_row),
         cons: Box::new(|_, _| Ok(Some(None))),
-        prefn: Some(Box::new(|_, _| {Ok(())})),
-        postfn: Some(Box::new(|_, _| {Ok(())})),
+        prefn: Some(Box::new(|_, _| Ok(()))),
+        postfn: Some(Box::new(|_, _| Ok(()))),
     })
 }
 
@@ -1891,7 +1917,7 @@ fn render_table_row<T: Write, D: TextDecorator>(
                 panic!()
             }
         })),
-        postfn: Some(Box::new(|_renderer: &mut TextRenderer<D>, _| {Ok(())})),
+        postfn: Some(Box::new(|_renderer: &mut TextRenderer<D>, _| Ok(()))),
     }
 }
 
@@ -1916,7 +1942,7 @@ fn render_table_row_vert<T: Write, D: TextDecorator>(
                 Err(Error::Fail)
             }
         })),
-        postfn: Some(Box::new(|_renderer: &mut TextRenderer<D>, _| {Ok(())})),
+        postfn: Some(Box::new(|_renderer: &mut TextRenderer<D>, _| Ok(()))),
     }
 }
 
@@ -1935,12 +1961,15 @@ pub mod config {
     //! Configure the HTML to text translation using the `Config` type, which can be
     //! constructed using one of the functions in this module.
 
-    use crate::{render::text_renderer::{
-        PlainDecorator, RichDecorator, TaggedLine, TextDecorator, RichAnnotation
-    }, Result, RenderTree, HtmlContext, MIN_WIDTH};
+    use super::{Discard, Error};
     #[cfg(feature = "css")]
     use crate::css::StyleData;
-    use super::{Discard, Error};
+    use crate::{
+        render::text_renderer::{
+            PlainDecorator, RichAnnotation, RichDecorator, TaggedLine, TextDecorator,
+        },
+        HtmlContext, RenderTree, Result, MIN_WIDTH,
+    };
 
     /// Configure the HTML processing.
     pub struct Config<D: TextDecorator> {
@@ -1975,10 +2004,12 @@ pub mod config {
             }
         }
         /// Parse with context.
-        fn do_parse<R: std::io::Read>(&mut self, context: &mut HtmlContext, input: R) -> Result<RenderTree> {
-            super::parse_with_context(
-                input,
-                context)
+        fn do_parse<R: std::io::Read>(
+            &mut self,
+            context: &mut HtmlContext,
+            input: R,
+        ) -> Result<RenderTree> {
+            super::parse_with_context(input, context)
         }
 
         /// Parse the HTML into a DOM structure.
@@ -1998,17 +2029,24 @@ pub mod config {
 
         /// Convert an HTML DOM into a RenderTree.
         pub fn dom_to_render_tree(&self, dom: &super::RcDom) -> Result<RenderTree> {
-            Ok(RenderTree(super::dom_to_render_tree_with_context(
+            Ok(RenderTree(
+                super::dom_to_render_tree_with_context(
                     dom.document.clone(),
                     &mut Discard {},
-                    &mut self.make_context())?
-                    .ok_or(Error::Fail)?))
+                    &mut self.make_context(),
+                )?
+                .ok_or(Error::Fail)?,
+            ))
         }
 
         /// Render an existing RenderTree into a string.
         pub fn render_to_string(&self, render_tree: RenderTree, width: usize) -> Result<String> {
-            Ok(render_tree.render_with_context(
-                &mut self.make_context(), width, self.decorator.make_subblock_decorator())?
+            Ok(render_tree
+                .render_with_context(
+                    &mut self.make_context(),
+                    width,
+                    self.decorator.make_subblock_decorator(),
+                )?
                 .into_string()?)
         }
 
@@ -2016,15 +2054,27 @@ pub mod config {
         /// The text is returned as a `Vec<TaggedLine<_>>`; the annotations are vectors
         /// of the provided text decorator's `Annotation`.  The "outer" annotation comes first in
         /// the `Vec`.
-        pub fn render_to_lines(&self, render_tree: RenderTree, width: usize) -> Result<Vec<TaggedLine<Vec<D::Annotation>>>> {
-            Ok(render_tree.render_with_context(
-                &mut self.make_context(), width, self.decorator.make_subblock_decorator())?
+        pub fn render_to_lines(
+            &self,
+            render_tree: RenderTree,
+            width: usize,
+        ) -> Result<Vec<TaggedLine<Vec<D::Annotation>>>> {
+            Ok(render_tree
+                .render_with_context(
+                    &mut self.make_context(),
+                    width,
+                    self.decorator.make_subblock_decorator(),
+                )?
                 .into_lines()?)
         }
 
         /// Reads HTML from `input`, and returns a `String` with text wrapped to
         /// `width` columns.
-        pub fn string_from_read<R: std::io::Read>(mut self, input: R, width: usize) -> Result<String> {
+        pub fn string_from_read<R: std::io::Read>(
+            mut self,
+            input: R,
+            width: usize,
+        ) -> Result<String> {
             let mut context = self.make_context();
             Ok(self.do_parse(&mut context, input)?
                .render_with_context(&mut context, width, self.decorator)?
@@ -2035,9 +2085,14 @@ pub mod config {
         /// The text is returned as a `Vec<TaggedLine<_>>`; the annotations are vectors
         /// of the provided text decorator's `Annotation`.  The "outer" annotation comes first in
         /// the `Vec`.
-        pub fn lines_from_read<R: std::io::Read>(mut self, input: R, width: usize) -> Result<Vec<TaggedLine<Vec<D::Annotation>>>> {
+        pub fn lines_from_read<R: std::io::Read>(
+            mut self,
+            input: R,
+            width: usize,
+        ) -> Result<Vec<TaggedLine<Vec<D::Annotation>>>> {
             let mut context = self.make_context();
-            Ok(self.do_parse(&mut context, input)?
+            Ok(self
+                .do_parse(&mut context, input)?
                 .render_with_context(&mut context, width, self.decorator)?
                 .into_lines()?)
         }
@@ -2109,7 +2164,8 @@ pub mod config {
             use std::fmt::Write;
 
             let mut context = self.make_context();
-            let lines = self.do_parse(&mut context, input)?
+            let lines = self
+                .do_parse(&mut context, input)?
                 .render_with_context(&mut context, width, self.decorator)?
                 .into_lines()?;
 
@@ -2205,7 +2261,12 @@ pub struct RenderTree(RenderNode);
 
 impl RenderTree {
     /// Render this document using the given `decorator` and wrap it to `width` columns.
-    fn render_with_context<D: TextDecorator>(self, context: &mut HtmlContext, width: usize, decorator: D) -> Result<RenderedText<D>> {
+    fn render_with_context<D: TextDecorator>(
+        self,
+        context: &mut HtmlContext,
+        width: usize,
+        decorator: D,
+    ) -> Result<RenderedText<D>> {
         if width == 0 {
             return Err(Error::TooNarrow);
         }
@@ -2216,7 +2277,8 @@ impl RenderTree {
         render_options.allow_width_overflow = context.allow_width_overflow;
         let test_decorator = decorator.make_subblock_decorator();
         let builder = SubRenderer::new(width, render_options, decorator);
-        let builder = render_tree_to_string(context, builder, &test_decorator, self.0, &mut Discard {})?;
+        let builder =
+            render_tree_to_string(context, builder, &test_decorator, self.0, &mut Discard {})?;
         Ok(RenderedText(builder))
     }
 
@@ -2254,7 +2316,8 @@ impl<D: TextDecorator> RenderedText<D> {
     /// Convert the rendered HTML document to a vector of lines with the annotations created by the
     /// decorator.
     pub fn into_lines(self) -> Result<Vec<TaggedLine<Vec<D::Annotation>>>> {
-        Ok(self.0
+        Ok(self
+            .0
             .into_lines()?
             .into_iter()
             .map(RenderLine::into_tagged_line)
@@ -2262,9 +2325,7 @@ impl<D: TextDecorator> RenderedText<D> {
     }
 }
 
-fn parse_with_context(mut input: impl io::Read,
-                      context: &mut HtmlContext,
-                      ) -> Result<RenderTree> {
+fn parse_with_context(mut input: impl io::Read, context: &mut HtmlContext) -> Result<RenderTree> {
     let opts = ParseOpts {
         tree_builder: TreeBuilderOpts {
             drop_doctype: true,
@@ -2276,8 +2337,9 @@ fn parse_with_context(mut input: impl io::Read,
         .from_utf8()
         .read_from(&mut input)
         .unwrap();
-    let render_tree = dom_to_render_tree_with_context(dom.document.clone(), &mut Discard {}, context)?
-        .ok_or(Error::Fail)?;
+    let render_tree =
+        dom_to_render_tree_with_context(dom.document.clone(), &mut Discard {}, context)?
+            .ok_or(Error::Fail)?;
     Ok(RenderTree(render_tree))
 }
 
@@ -2294,8 +2356,8 @@ where
     D: TextDecorator,
 {
     config::with_decorator(decorator)
-           .string_from_read(input, width)
-           .expect("Failed to convert to HTML")
+        .string_from_read(input, width)
+        .expect("Failed to convert to HTML")
 }
 
 /// Reads HTML from `input`, and returns a `String` with text wrapped to
@@ -2305,8 +2367,8 @@ where
     R: io::Read,
 {
     config::plain()
-           .string_from_read(input, width)
-           .expect("Failed to convert to HTML")
+        .string_from_read(input, width)
+        .expect("Failed to convert to HTML")
 }
 
 /// Reads HTML from `input`, and returns text wrapped to `width` columns.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1063,6 +1063,7 @@ struct HtmlContext {
     pad_block_width: bool,
     allow_width_overflow: bool,
     min_wrap_width: usize,
+    raw: bool,
 }
 
 fn dom_to_render_tree_with_context<T: Write>(
@@ -1563,8 +1564,11 @@ fn do_render_node<'b, T: Write, D: TextDecorator>(
             debug_assert!(prefix.len() == prefix_size);
             let min_width = size_estimate.min_width;
             let inner_width = min_width.saturating_sub(prefix_size);
-            let sub_builder =
-                renderer.new_sub_renderer(renderer.width_minus(prefix_size, inner_width)?)?;
+            let sub_builder = renderer.new_sub_renderer(if renderer.options.raw {
+                renderer.width
+            } else {
+                renderer.width_minus(prefix_size, inner_width)?
+            })?;
             renderer.push(sub_builder);
             pending2(children, move |renderer: &mut TextRenderer<D>, _| {
                 let sub_builder = renderer.pop();
@@ -1595,8 +1599,11 @@ fn do_render_node<'b, T: Write, D: TextDecorator>(
             let prefix = renderer.quote_prefix();
             debug_assert!(size_estimate.prefix_size == prefix.len());
             let inner_width = size_estimate.min_width - prefix.len();
-            let sub_builder =
-                renderer.new_sub_renderer(renderer.width_minus(prefix.len(), inner_width)?)?;
+            let sub_builder = renderer.new_sub_renderer(if renderer.options.raw {
+                renderer.width
+            } else {
+                renderer.width_minus(prefix.len(), inner_width)?
+            })?;
             renderer.push(sub_builder);
             pending2(children, move |renderer: &mut TextRenderer<D>, _| {
                 let sub_builder = renderer.pop();
@@ -1618,8 +1625,11 @@ fn do_render_node<'b, T: Write, D: TextDecorator>(
                 cons: Box::new(|_, _| Ok(Some(None))),
                 prefn: Some(Box::new(move |renderer: &mut TextRenderer<D>, _| {
                     let inner_width = size_estimate.min_width - prefix_len;
-                    let sub_builder = renderer
-                        .new_sub_renderer(renderer.width_minus(prefix_len, inner_width)?)?;
+                    let sub_builder = renderer.new_sub_renderer(if renderer.options.raw {
+                        renderer.width
+                    } else {
+                        renderer.width_minus(prefix_len, inner_width)?
+                    })?;
                     renderer.push(sub_builder);
                     Ok(())
                 })),
@@ -1656,8 +1666,11 @@ fn do_render_node<'b, T: Write, D: TextDecorator>(
                 cons: Box::new(|_, _| Ok(Some(None))),
                 prefn: Some(Box::new(move |renderer: &mut TextRenderer<D>, _| {
                     let inner_min = size_estimate.min_width - size_estimate.prefix_size;
-                    let sub_builder = renderer
-                        .new_sub_renderer(renderer.width_minus(prefix_width, inner_min)?)?;
+                    let sub_builder = renderer.new_sub_renderer(if renderer.options.raw {
+                        renderer.width
+                    } else {
+                        renderer.width_minus(prefix_width, inner_min)?
+                    })?;
                     renderer.push(sub_builder);
                     Ok(())
                 })),
@@ -1695,7 +1708,11 @@ fn do_render_node<'b, T: Write, D: TextDecorator>(
         }
         Dd(children) => {
             let inner_min = size_estimate.min_width - 2;
-            let sub_builder = renderer.new_sub_renderer(renderer.width_minus(2, inner_min)?)?;
+            let sub_builder = renderer.new_sub_renderer(if renderer.options.raw {
+                renderer.width
+            } else {
+                renderer.width_minus(2, inner_min)?
+            })?;
             renderer.push(sub_builder);
             pending2(children, |renderer: &mut TextRenderer<D>, _| {
                 let sub_builder = renderer.pop();
@@ -1866,7 +1883,9 @@ fn render_table_tree<T: Write, D: TextDecorator>(
 
     renderer.start_block()?;
 
-    renderer.add_horizontal_border_width(table_width)?;
+    if !renderer.options.raw {
+        renderer.add_horizontal_border_width(table_width)?;
+    }
 
     Ok(TreeMapResult::PendingChildren {
         children: table.into_rows(col_widths, vert_row),
@@ -1881,18 +1900,23 @@ fn render_table_row<T: Write, D: TextDecorator>(
     row: RenderTableRow,
     _err_out: &mut T,
 ) -> TreeMapResult<'static, TextRenderer<D>, RenderNode, Option<SubRenderer<D>>> {
+    let raw = _renderer.options.raw;
     TreeMapResult::PendingChildren {
         children: row.into_cells(false),
-        cons: Box::new(|builders, children| {
+        cons: Box::new(move |builders, children| {
             let children: Vec<_> = children.into_iter().map(Option::unwrap).collect();
             if children.iter().any(|c| !c.empty()) {
-                builders.append_columns_with_borders(children, true)?;
+                builders.append_columns_with_borders(children, true, raw)?;
             }
             Ok(Some(None))
         }),
-        prefn: Some(Box::new(|renderer: &mut TextRenderer<D>, node| {
+        prefn: Some(Box::new(move |renderer: &mut TextRenderer<D>, node| {
             if let RenderNodeInfo::TableCell(ref cell) = node.info {
-                let sub_builder = renderer.new_sub_renderer(cell.col_width.unwrap())?;
+                let sub_builder = renderer.new_sub_renderer(if renderer.options.raw {
+                    renderer.width
+                } else {
+                    cell.col_width.unwrap()
+                })?;
                 renderer.push(sub_builder);
                 Ok(())
             } else {
@@ -1915,9 +1939,13 @@ fn render_table_row_vert<T: Write, D: TextDecorator>(
             builders.append_vert_row(children)?;
             Ok(Some(None))
         }),
-        prefn: Some(Box::new(|renderer: &mut TextRenderer<D>, node| {
+        prefn: Some(Box::new(move |renderer: &mut TextRenderer<D>, node| {
             if let RenderNodeInfo::TableCell(ref cell) = node.info {
-                let sub_builder = renderer.new_sub_renderer(cell.col_width.unwrap())?;
+                let sub_builder = renderer.new_sub_renderer(if renderer.options.raw {
+                    renderer.width
+                } else {
+                    cell.col_width.unwrap()
+                })?;
                 renderer.push(sub_builder);
                 Ok(())
             } else {
@@ -1968,6 +1996,7 @@ pub mod config {
 
         allow_width_overflow: bool,
         min_wrap_width: usize,
+        raw: bool,
     }
 
     impl<D: TextDecorator> Config<D> {
@@ -1983,6 +2012,7 @@ pub mod config {
                 pad_block_width: self.pad_block_width,
                 allow_width_overflow: self.allow_width_overflow,
                 min_wrap_width: self.min_wrap_width,
+                raw: self.raw,
             }
         }
         /// Parse with context.
@@ -2125,6 +2155,13 @@ pub mod config {
             self.min_wrap_width = min_wrap_width;
             self
         }
+
+        /// Raw extraction, ensures text in table cells ends up rendered together
+        /// This traverses tables as if they had a single column and every cell is its own row.
+        pub fn raw_mode(mut self, raw: bool) -> Self {
+            self.raw = raw;
+            self
+        }
     }
 
     impl Config<RichDecorator> {
@@ -2199,6 +2236,7 @@ pub mod config {
             pad_block_width: false,
             allow_width_overflow: false,
             min_wrap_width: MIN_WIDTH,
+            raw: false,
         }
     }
 
@@ -2214,6 +2252,7 @@ pub mod config {
             pad_block_width: false,
             allow_width_overflow: false,
             min_wrap_width: MIN_WIDTH,
+            raw: false,
         }
     }
 
@@ -2229,6 +2268,7 @@ pub mod config {
             pad_block_width: false,
             allow_width_overflow: false,
             min_wrap_width: MIN_WIDTH,
+            raw: false,
         }
     }
 }
@@ -2256,6 +2296,7 @@ impl RenderTree {
         render_options.pad_block_width = context.pad_block_width;
         render_options.min_wrap_width = context.min_wrap_width;
         render_options.allow_width_overflow = context.allow_width_overflow;
+        render_options.raw = context.raw;
         let test_decorator = decorator.make_subblock_decorator();
         let builder = SubRenderer::new(width, render_options, decorator);
         let builder =

--- a/src/markup5ever_rcdom.rs
+++ b/src/markup5ever_rcdom.rs
@@ -127,9 +127,9 @@ impl Node {
 
 impl Drop for Node {
     fn drop(&mut self) {
-        let mut nodes = mem::replace(&mut *self.children.borrow_mut(), vec![]);
+        let mut nodes = mem::take(&mut *self.children.borrow_mut());
         while let Some(node) = nodes.pop() {
-            let children = mem::replace(&mut *node.children.borrow_mut(), vec![]);
+            let children = mem::take(&mut *node.children.borrow_mut());
             nodes.extend(children.into_iter());
             if let NodeData::Element {
                 ref template_contents,
@@ -177,7 +177,7 @@ fn get_parent_and_index(target: &Handle) -> Option<(Handle, usize)> {
             .borrow()
             .iter()
             .enumerate()
-            .find(|&(_, child)| Rc::ptr_eq(&child, &target))
+            .find(|&(_, child)| Rc::ptr_eq(child, target))
         {
             Some((i, _)) => i,
             None => panic!("have parent but couldn't find in parent's children!"),
@@ -295,20 +295,16 @@ impl TreeSink for RcDom {
 
     fn append(&mut self, parent: &Handle, child: NodeOrText<Handle>) {
         // Append to an existing Text node if we have one.
-        match child {
-            NodeOrText::AppendText(ref text) => match parent.children.borrow().last() {
-                Some(h) => {
-                    if append_to_existing_text(h, &text) {
-                        return;
-                    }
+        if let NodeOrText::AppendText(text) = &child {
+            if let Some(h) = parent.children.borrow().last() {
+                if append_to_existing_text(h, text) {
+                    return;
                 }
-                _ => (),
-            },
-            _ => (),
+            }
         }
 
         append(
-            &parent,
+            parent,
             match child {
                 NodeOrText::AppendText(text) => Node::new(NodeData::Text {
                     contents: RefCell::new(text),
@@ -319,7 +315,7 @@ impl TreeSink for RcDom {
     }
 
     fn append_before_sibling(&mut self, sibling: &Handle, child: NodeOrText<Handle>) {
-        let (parent, i) = get_parent_and_index(&sibling)
+        let (parent, i) = get_parent_and_index(sibling)
             .expect("append_before_sibling called on node without parent");
 
         let child = match (child, i) {
@@ -405,20 +401,20 @@ impl TreeSink for RcDom {
     }
 
     fn remove_from_parent(&mut self, target: &Handle) {
-        remove_from_parent(&target);
+        remove_from_parent(target);
     }
 
     fn reparent_children(&mut self, node: &Handle, new_parent: &Handle) {
         let mut children = node.children.borrow_mut();
         let mut new_children = new_parent.children.borrow_mut();
         for child in children.iter() {
-            let previous_parent = child.parent.replace(Some(Rc::downgrade(&new_parent)));
+            let previous_parent = child.parent.replace(Some(Rc::downgrade(new_parent)));
             assert!(Rc::ptr_eq(
-                &node,
+                node,
                 &previous_parent.unwrap().upgrade().expect("dangling weak")
             ))
         }
-        new_children.extend(mem::replace(&mut *children, Vec::new()));
+        new_children.extend(mem::take(&mut *children));
     }
 
     fn is_mathml_annotation_xml_integration_point(&self, target: &Handle) -> bool {
@@ -495,11 +491,11 @@ impl Serialize for SerializableHandle {
                         }
                     }
 
-                    NodeData::Doctype { ref name, .. } => serializer.write_doctype(&name)?,
+                    NodeData::Doctype { ref name, .. } => serializer.write_doctype(name)?,
 
                     NodeData::Text { ref contents } => serializer.write_text(&contents.borrow())?,
 
-                    NodeData::Comment { ref contents } => serializer.write_comment(&contents)?,
+                    NodeData::Comment { ref contents } => serializer.write_comment(contents)?,
 
                     NodeData::ProcessingInstruction {
                         ref target,

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -71,6 +71,7 @@ pub trait Renderer {
         cols: I,
         collapse: bool,
         raw: bool,
+        draw_borders: bool,
     ) -> Result<(), Error>
     where
         I: IntoIterator<Item = Self>,

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -66,7 +66,12 @@ pub trait Renderer {
     /// and add a horizontal line below.
     /// If collapse is true, then merge top/bottom borders of the subrenderer
     /// with the surrounding one.
-    fn append_columns_with_borders<I>(&mut self, cols: I, collapse: bool) -> Result<(), Error>
+    fn append_columns_with_borders<I>(
+        &mut self,
+        cols: I,
+        collapse: bool,
+        raw: bool,
+    ) -> Result<(), Error>
     where
         I: IntoIterator<Item = Self>,
         Self: Sized;

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -12,7 +12,9 @@ pub trait Renderer {
     fn add_empty_line(&mut self) -> crate::Result<()>;
 
     /// Create a sub-renderer for nested blocks.
-    fn new_sub_renderer(&self, width: usize) -> crate::Result<Self> where Self: Sized;
+    fn new_sub_renderer(&self, width: usize) -> crate::Result<Self>
+    where
+        Self: Sized;
 
     /// Start a new block.
     fn start_block(&mut self) -> crate::Result<()>;
@@ -30,8 +32,10 @@ pub trait Renderer {
     fn add_horizontal_border(&mut self) -> Result<(), Error>;
 
     /// Add a horizontal border which is not the full width
-    fn add_horizontal_border_width(&mut self, #[allow(unused_variables)] width: usize)
-    -> Result<(), Error> {
+    fn add_horizontal_border_width(
+        &mut self,
+        #[allow(unused_variables)] width: usize,
+    ) -> Result<(), Error> {
         self.add_horizontal_border()
     }
 
@@ -54,8 +58,7 @@ pub trait Renderer {
 
     /// Add a new block from a sub renderer, and prefix every line by the
     /// corresponding text from each iteration of prefixes.
-    fn append_subrender<'a, I>(&mut self, other: Self, prefixes: I)
-    -> Result<(), Error>
+    fn append_subrender<'a, I>(&mut self, other: Self, prefixes: I) -> Result<(), Error>
     where
         I: Iterator<Item = &'a str>;
 
@@ -63,8 +66,7 @@ pub trait Renderer {
     /// and add a horizontal line below.
     /// If collapse is true, then merge top/bottom borders of the subrenderer
     /// with the surrounding one.
-    fn append_columns_with_borders<I>(&mut self, cols: I, collapse: bool)
-    -> Result<(), Error>
+    fn append_columns_with_borders<I>(&mut self, cols: I, collapse: bool) -> Result<(), Error>
     where
         I: IntoIterator<Item = Self>,
         Self: Sized;

--- a/src/render/text_renderer.rs
+++ b/src/render/text_renderer.rs
@@ -948,6 +948,9 @@ pub struct RenderOptions {
     /// Raw extraction, ensures text in table cells ends up rendered together
     /// This traverses tables as if they had a single column and every cell is its own row.
     pub raw: bool,
+
+    /// Whether to draw table borders
+    pub draw_borders: bool,
 }
 
 impl Default for RenderOptions {
@@ -958,6 +961,7 @@ impl Default for RenderOptions {
             allow_width_overflow: Default::default(),
             pad_block_width: Default::default(),
             raw: false,
+            draw_borders: true,
         }
     }
 }
@@ -1317,6 +1321,7 @@ impl<D: TextDecorator> Renderer for SubRenderer<D> {
         cols: I,
         collapse: bool,
         raw: bool,
+        draw_borders: bool,
     ) -> Result<(), Error>
     where
         I: IntoIterator<Item = Self>,
@@ -1432,11 +1437,11 @@ impl<D: TextDecorator> Renderer for SubRenderer<D> {
              line: &mut TaggedLine<Vec<D::Annotation>>,
              opt: Option<&mut RenderLine<Vec<D::Annotation>>>| match opt {
                 Some(RenderLine::Text(tline)) => line.consume(tline),
-                Some(RenderLine::Line(bord)) if !raw => line.push(Str(TaggedString {
+                Some(RenderLine::Line(_)) if !draw_borders || raw => {}
+                Some(RenderLine::Line(bord)) => line.push(Str(TaggedString {
                     s: bord.to_string(),
                     tag: self.ann_stack.clone(),
                 })),
-                Some(RenderLine::Line(_)) => {}
                 None => line.push(Str(TaggedString {
                     s: column_padding[cellno]
                         .clone()
@@ -1460,13 +1465,15 @@ impl<D: TextDecorator> Renderer for SubRenderer<D> {
             for (cellno, &mut (width, ref mut ls)) in line_sets.iter_mut().enumerate() {
                 attach_line(cellno, width, &mut line, ls.get_mut(i));
                 if cellno != last_cellno {
-                    line.push_char('│', &self.ann_stack);
+                    line.push_char(if draw_borders { '│' } else { ' ' }, &self.ann_stack);
                 }
             }
             self.lines.push_back(RenderLine::Text(line));
             line = TaggedLine::new();
         }
-        self.lines.push_back(RenderLine::Line(next_border));
+        if draw_borders {
+            self.lines.push_back(RenderLine::Line(next_border));
+        }
         Ok(())
     }
 

--- a/src/render/text_renderer.rs
+++ b/src/render/text_renderer.rs
@@ -1135,9 +1135,6 @@ impl<D: TextDecorator> Renderer for SubRenderer<D> {
     }
 
     fn new_sub_renderer(&self, width: usize) -> crate::Result<Self> {
-        if width < 1 {
-            return Err(Error::TooNarrow);
-        }
         let mut result = SubRenderer::new(
             width,
             self.options.clone(),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1706,6 +1706,19 @@ const MULTILINE_CELLS: &str = "<table><tr>
 </table>";
 
 #[test]
+fn test_table_without_borders() {
+    let expected = "Aliquam erat volutpat. Nunc eleifend leo     Lorem ipsum dolor sit amet,       
+vitae magna. In id erat non orci commodo     consectetuer adipiscing elit.     
+lobortis.                                    Donec hendrerit tempor tellus.    
+Aliquam erat volutpat.                                                         \n";
+    let s = config::with_decorator(TrivialDecorator::new())
+        .no_table_borders()
+        .string_from_read(MULTILINE_CELLS.as_bytes(), 80)
+        .unwrap();
+    assert_eq!(s, expected);
+}
+
+#[test]
 fn test_table_raw_mode() {
     let expected =
         "Aliquam erat volutpat. Nunc eleifend leo vitae magna. In id erat non orci       

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1950,6 +1950,22 @@ fn test_overflow_wide_char() {
         c.min_wrap_width(1).allow_width_overflow()
     });
 }
+
+#[test]
+fn test_table_too_narrow() {
+    let tbl = "<table><tr>
+    <td><ol><li></li></ol></td>
+    <td>
+        <ol><li>Aliquam erat volutpat. Lorem ipsum dolor sit amet,</li></ol>
+    </td>
+    <td>
+        <ol><li>Lorem ipsum dolor sit</li></ol>
+    </td>
+</tr></table>"
+        .as_bytes();
+    from_read(tbl, 80);
+}
+
 #[cfg(feature = "css")]
 mod css_tests {
     use super::{test_html_coloured, test_html_css, test_html_style};

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1689,6 +1689,37 @@ der
     );
 }
 
+const MULTILINE_CELLS: &str = "<table><tr>
+    <td><ol><li></li></ol></td>
+    <td><ol><li>
+        Aliquam erat volutpat.  Nunc eleifend leo vitae magna.  In id erat non orci commodo lobortis.
+    </li>
+    <li>
+        Aliquam erat volutpat.
+    </li>
+    <li></li>
+    </ol></td>
+    <td><ol><li>
+        Lorem ipsum dolor sit amet, consectetuer adipiscing elit.  Donec hendrerit tempor tellus.
+    </li></ol></td>
+</tr>
+</table>";
+
+#[test]
+fn test_table_raw_mode() {
+    let expected =
+        "Aliquam erat volutpat. Nunc eleifend leo vitae magna. In id erat non orci       
+commodo lobortis.                                                               
+Aliquam erat volutpat.                                                          
+Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Donec hendrerit tempor
+tellus.                                                                         \n";
+    let s = config::with_decorator(TrivialDecorator::new())
+        .raw_mode(true)
+        .string_from_read(MULTILINE_CELLS.as_bytes(), 80)
+        .unwrap();
+    assert_eq!(s, expected);
+}
+
 #[test]
 fn test_unicode() {
     test_html(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -21,80 +21,80 @@ fn test_html(input: &[u8], expected: &str, width: usize) {
 }
 #[track_caller]
 fn test_html_conf<F>(input: &[u8], expected: &str, width: usize, conf: F)
-    where F: Fn(Config<PlainDecorator>) -> Config<PlainDecorator>
+where
+    F: Fn(Config<PlainDecorator>) -> Config<PlainDecorator>,
 {
     let result = conf(config::plain())
-        .string_from_read(input, width).unwrap();
+        .string_from_read(input, width)
+        .unwrap();
     assert_eq_str!(result, expected);
 }
 #[track_caller]
 fn test_html_maxwrap(input: &[u8], expected: &str, width: usize, wrap_width: usize) {
-    test_html_conf(input, expected, width, |conf| conf.max_wrap_width(wrap_width))
+    test_html_conf(input, expected, width, |conf| {
+        conf.max_wrap_width(wrap_width)
+    })
 }
 #[cfg(feature = "css")]
 fn test_html_css(input: &[u8], expected: &str, width: usize) {
     let result = config::plain()
         .use_doc_css()
-        .string_from_read(input, width).unwrap();
+        .string_from_read(input, width)
+        .unwrap();
     assert_eq_str!(result, expected);
 }
 #[cfg(feature = "css")]
-fn test_colour_map(annotations: &[RichAnnotation], s: &str) -> String
-{
+fn test_colour_map(annotations: &[RichAnnotation], s: &str) -> String {
     let mut tags = ("", "");
     let mut bgtags = ("", "");
     for ann in annotations {
         match ann {
-            RichAnnotation::Colour(c) => {
-                match c {
-                    crate::Colour{
-                        r: 0xff,
-                        g: 0,
-                        b: 0
-                    } => {
-                        tags = ("<R>", "</R>");
-                    }
-                    crate::Colour{
-                        r: 0xff,
-                        g: 0xff,
-                        b: 0xff
-                    } => {
-                        tags = ("<W>", "</W>");
-                    }
-                    crate::Colour{
-                        r: 0,
-                        g: 0xff,
-                        b: 0
-                    } => {
-                        tags = ("<G>", "</G>");
-                    }
-                    _ => {
-                        tags = ("<?>", "</?>");
-                    }
+            RichAnnotation::Colour(c) => match c {
+                crate::Colour {
+                    r: 0xff,
+                    g: 0,
+                    b: 0,
+                } => {
+                    tags = ("<R>", "</R>");
                 }
-            }
-            RichAnnotation::BgColour(c) => {
-                match c {
-                    crate::Colour{
-                        r: 0xff,
-                        g: 0,
-                        b: 0
-                    } => {
-                        bgtags = ("<r>", "</r>");
-                    }
-                    crate::Colour{
-                        r: 0,
-                        g: 0xff,
-                        b: 0
-                    } => {
-                        bgtags = ("<g>", "</g>");
-                    }
-                    _ => {
-                        bgtags = ("<.>", "</.>");
-                    }
+                crate::Colour {
+                    r: 0xff,
+                    g: 0xff,
+                    b: 0xff,
+                } => {
+                    tags = ("<W>", "</W>");
                 }
-            }
-            _ => ()
+                crate::Colour {
+                    r: 0,
+                    g: 0xff,
+                    b: 0,
+                } => {
+                    tags = ("<G>", "</G>");
+                }
+                _ => {
+                    tags = ("<?>", "</?>");
+                }
+            },
+            RichAnnotation::BgColour(c) => match c {
+                crate::Colour {
+                    r: 0xff,
+                    g: 0,
+                    b: 0,
+                } => {
+                    bgtags = ("<r>", "</r>");
+                }
+                crate::Colour {
+                    r: 0,
+                    g: 0xff,
+                    b: 0,
+                } => {
+                    bgtags = ("<g>", "</g>");
+                }
+                _ => {
+                    bgtags = ("<.>", "</.>");
+                }
+            },
+            _ => (),
         }
     }
     format!("{}{}{}{}{}", bgtags.0, tags.0, s, tags.1, bgtags.1)
@@ -105,15 +105,16 @@ fn test_colour_map(annotations: &[RichAnnotation], s: &str) -> String
 fn test_html_coloured(input: &[u8], expected: &str, width: usize) {
     let result = config::rich()
         .use_doc_css()
-        .coloured(input, width, test_colour_map).unwrap();
+        .coloured(input, width, test_colour_map)
+        .unwrap();
     assert_eq_str!(result, expected);
 }
 #[track_caller]
 fn test_html_err_conf<F>(input: &[u8], expected: Error, width: usize, conf: F)
-    where F: Fn(Config<PlainDecorator>) -> Config<PlainDecorator>
+where
+    F: Fn(Config<PlainDecorator>) -> Config<PlainDecorator>,
 {
-    let result = conf(config::plain())
-        .string_from_read(input, width);
+    let result = conf(config::plain()).string_from_read(input, width);
     match result {
         Err(e) => {
             assert_eq!(e, expected);
@@ -133,7 +134,8 @@ fn test_html_style(input: &[u8], style: &str, expected: &str, width: usize) {
     let result = config::plain()
         .add_css(style)
         .unwrap()
-        .string_from_read(input, width).unwrap();
+        .string_from_read(input, width)
+        .unwrap();
     assert_eq_str!(result, expected);
 }
 
@@ -713,7 +715,8 @@ wrapped.
 
 #[test]
 fn test_wrap_max() {
-    test_html_maxwrap(br#"
+    test_html_maxwrap(
+        br#"
         <p>This is a bit of text to wrap<p>
         <ul>
           <li>This is a bit of text to wrap too</li>
@@ -729,12 +732,16 @@ wrap
   bit of
   text to
   wrap too
-"#, 20, 10)
+"#,
+        20,
+        10,
+    )
 }
 
 #[test]
 fn test_wrap_max2() {
-    test_html_maxwrap(br#"
+    test_html_maxwrap(
+        br#"
         <p>plain para at the full screen width</p>
         <ul>
           <li>bullet point uses same width so its margin is 2 chars further right
@@ -758,77 +765,48 @@ full screen width
     * result: you never
       get text squashed
       too narrow
-"#, 80, 17);
+"#,
+        80,
+        17,
+    );
 }
 
 #[test]
 fn test_wrap_word_boundaries() {
-    test_html(br#"Hello there boo"#,
-              "Hello there boo\n",
-              20);
-    test_html(br#"Hello there boo"#,
-              "Hello there boo\n",
-              15);
-    test_html(br#"Hello there boo"#,
-              "Hello there\nboo\n",
-              14);
-    test_html(br#"Hello there boo"#,
-              "Hello there\nboo\n",
-              13);
-    test_html(br#"Hello there boo"#,
-              "Hello there\nboo\n",
-              12);
-    test_html(br#"Hello there boo"#,
-              "Hello there\nboo\n",
-              11);
-    test_html(br#"Hello there boo"#,
-              "Hello\nthere boo\n",
-              10);
-    test_html(br#"Hello there boo"#,
-              "Hello\nthere\nboo\n",
-              6);
-    test_html(br#"Hello there boo"#,
-              "Hello\nthere\nboo\n",
-              5);
-    test_html(br#"Hello there boo"#,
-              "Hell\no\nther\ne\nboo\n",
-              4);
-    test_html(br#"Hello there boo"#,
-              "H\ne\nl\nl\no\nt\nh\ne\nr\ne\nb\no\no\n",
-              1);
-    test_html(br#"Hello <em>there</em> boo"#,
-              "Hello *there* boo\n",
-              20);
-    test_html(br#"Hello <em>there</em> boo"#,
-              "Hello *there*\nboo\n",
-              15);
-    test_html(br#"Hello <em>there</em> boo"#,
-              "Hello *there*\nboo\n",
-              14);
-    test_html(br#"Hello <em>there</em> boo"#,
-              "Hello *there*\nboo\n",
-              13);
-    test_html(br#"Hello <em>there</em> boo"#,
-              "Hello\n*there* boo\n",
-              12);
-    test_html(br#"Hello <em>there</em> boo"#,
-              "Hello\n*there* boo\n",
-              11);
-    test_html(br#"Hello <em>there</em> boo"#,
-              "Hello\n*there*\nboo\n",
-              10);
-    test_html(br#"Hello <em>there</em> boo"#,
-              "Hello\n*there\n* boo\n",
-              6);
-    test_html(br#"Hello <em>there</em> boo"#,
-              "Hello\n*ther\ne*\nboo\n",
-              5);
-    test_html(br#"Hello <em>there</em> boo"#,
-              "Hell\no\n*the\nre*\nboo\n",
-              4);
-    test_html(br#"Hello <em>there</em> boo"#,
-              "H\ne\nl\nl\no\n*\nt\nh\ne\nr\ne\n*\nb\no\no\n",
-              1);
+    test_html(br#"Hello there boo"#, "Hello there boo\n", 20);
+    test_html(br#"Hello there boo"#, "Hello there boo\n", 15);
+    test_html(br#"Hello there boo"#, "Hello there\nboo\n", 14);
+    test_html(br#"Hello there boo"#, "Hello there\nboo\n", 13);
+    test_html(br#"Hello there boo"#, "Hello there\nboo\n", 12);
+    test_html(br#"Hello there boo"#, "Hello there\nboo\n", 11);
+    test_html(br#"Hello there boo"#, "Hello\nthere boo\n", 10);
+    test_html(br#"Hello there boo"#, "Hello\nthere\nboo\n", 6);
+    test_html(br#"Hello there boo"#, "Hello\nthere\nboo\n", 5);
+    test_html(br#"Hello there boo"#, "Hell\no\nther\ne\nboo\n", 4);
+    test_html(
+        br#"Hello there boo"#,
+        "H\ne\nl\nl\no\nt\nh\ne\nr\ne\nb\no\no\n",
+        1,
+    );
+    test_html(br#"Hello <em>there</em> boo"#, "Hello *there* boo\n", 20);
+    test_html(br#"Hello <em>there</em> boo"#, "Hello *there*\nboo\n", 15);
+    test_html(br#"Hello <em>there</em> boo"#, "Hello *there*\nboo\n", 14);
+    test_html(br#"Hello <em>there</em> boo"#, "Hello *there*\nboo\n", 13);
+    test_html(br#"Hello <em>there</em> boo"#, "Hello\n*there* boo\n", 12);
+    test_html(br#"Hello <em>there</em> boo"#, "Hello\n*there* boo\n", 11);
+    test_html(br#"Hello <em>there</em> boo"#, "Hello\n*there*\nboo\n", 10);
+    test_html(br#"Hello <em>there</em> boo"#, "Hello\n*there\n* boo\n", 6);
+    test_html(br#"Hello <em>there</em> boo"#, "Hello\n*ther\ne*\nboo\n", 5);
+    test_html(
+        br#"Hello <em>there</em> boo"#,
+        "Hell\no\n*the\nre*\nboo\n",
+        4,
+    );
+    test_html(
+        br#"Hello <em>there</em> boo"#,
+        "H\ne\nl\nl\no\n*\nt\nh\ne\nr\ne\n*\nb\no\no\n",
+        1,
+    );
 }
 
 #[test]
@@ -1831,7 +1809,42 @@ fn test_narrow_width_nested() {
 
 #[test]
 fn test_issue_93_x() {
-    let data=[60, 116, 97, 98, 108, 101, 62, 60, 116, 114, 62, 60, 116, 100, 62, 120, 105, 60, 48, 62, 0, 0, 0, 60, 116, 97, 98, 108, 101, 62, 58, 58, 58, 62, 58, 62, 62, 62, 58, 60, 112, 32, 32, 32, 32, 32, 32, 32, 71, 87, 85, 78, 16, 16, 62, 60, 15, 16, 16, 16, 16, 16, 16, 15, 38, 16, 16, 16, 15, 1, 16, 16, 16, 16, 16, 16, 162, 111, 107, 99, 91, 112, 57, 64, 94, 100, 60, 111, 108, 47, 62, 127, 60, 108, 73, 62, 125, 109, 121, 102, 99, 122, 110, 102, 114, 98, 60, 97, 32, 104, 114, 101, 102, 61, 98, 111, 103, 32, 105, 100, 61, 100, 62, 60, 111, 15, 15, 15, 15, 15, 15, 15, 39, 15, 15, 15, 106, 102, 59, 99, 32, 32, 32, 86, 102, 122, 110, 104, 93, 108, 71, 114, 117, 110, 100, 96, 121, 57, 60, 107, 116, 109, 247, 62, 60, 32, 60, 122, 98, 99, 98, 97, 32, 119, 127, 127, 62, 60, 112, 62, 121, 116, 60, 47, 116, 100, 62, 62, 60, 111, 98, 62, 123, 110, 109, 97, 101, 105, 119, 60, 112, 101, 101, 122, 102, 63, 120, 97, 62, 60, 101, 62, 60, 120, 109, 112, 32, 28, 52, 55, 50, 50, 49, 52, 185, 150, 99, 62, 255, 112, 76, 85, 60, 112, 62, 73, 100, 116, 116, 60, 75, 50, 73, 116, 120, 110, 127, 255, 118, 32, 42, 40, 49, 33, 112, 32, 36, 107, 57, 60, 5, 163, 62, 49, 55, 32, 33, 118, 99, 63, 60, 109, 107, 43, 119, 100, 62, 60, 104, 58, 101, 163, 163, 163, 163, 220, 220, 220, 220, 220, 220, 220, 220, 220, 220, 220, 220, 1, 107, 117, 107, 108, 44, 102, 58, 60, 116, 101, 97, 106, 98, 59, 60, 115, 109, 52, 58, 115, 98, 62, 232, 110, 114, 32, 60, 117, 93, 120, 112, 119, 111, 59, 98, 120, 61, 206, 19, 61, 206, 19, 59, 1, 110, 102, 60, 115, 0, 242, 64, 203, 8, 111, 50, 59, 121, 122, 32, 42, 35, 32, 37, 101, 120, 104, 121, 0, 242, 59, 63, 121, 231, 130, 130, 130, 170, 170, 1, 32, 0, 0, 0, 28, 134, 200, 90, 119, 48, 60, 111, 108, 118, 119, 116, 113, 59, 100, 60, 117, 43, 110, 99, 9, 216, 157, 137, 216, 157, 246, 167, 62, 60, 104, 61, 43, 28, 134, 200, 105, 119, 48, 60, 122, 110, 0, 242, 61, 61, 114, 231, 130, 130, 130, 170, 170, 170, 233, 222, 222, 162, 163, 163, 163, 163, 163, 163, 163, 85, 100, 116, 99, 61, 60, 163, 163, 163, 163, 163, 220, 220, 1, 109, 112, 105, 10, 59, 105, 220, 215, 10, 59, 122, 100, 100, 121, 97, 43, 43, 43, 102, 122, 100, 60, 62, 114, 116, 122, 115, 61, 60, 115, 101, 62, 215, 215, 215, 215, 215, 98, 59, 60, 109, 120, 57, 60, 97, 102, 113, 229, 43, 43, 43, 43, 43, 43, 43, 43, 43, 35, 43, 43, 101, 58, 60, 116, 98, 101, 107, 98, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 98, 99, 62, 60, 112, 102, 59, 124, 107, 111, 97, 98, 108, 118, 60, 116, 102, 101, 104, 97, 62, 60, 255, 127, 46, 60, 116, 101, 62, 60, 105, 102, 63, 116, 116, 60, 47, 116, 101, 62, 62, 60, 115, 98, 62, 123, 109, 108, 97, 100, 119, 118, 60, 111, 99, 97, 103, 99, 62, 60, 255, 127, 46, 60, 103, 99, 62, 60, 116, 98, 63, 60, 101, 62, 60, 109, 109, 231, 130, 130, 130, 213, 213, 213, 233, 222, 222, 59, 101, 103, 58, 60, 100, 111, 61, 65, 114, 104, 60, 47, 101, 109, 62, 60, 99, 99, 172, 97, 97, 58, 60, 119, 99, 64, 126, 118, 104, 100, 100, 107, 105, 60, 120, 98, 255, 255, 255, 0, 60, 255, 127, 46, 60, 113, 127];
+    let data = [
+        60, 116, 97, 98, 108, 101, 62, 60, 116, 114, 62, 60, 116, 100, 62, 120, 105, 60, 48, 62, 0,
+        0, 0, 60, 116, 97, 98, 108, 101, 62, 58, 58, 58, 62, 58, 62, 62, 62, 58, 60, 112, 32, 32,
+        32, 32, 32, 32, 32, 71, 87, 85, 78, 16, 16, 62, 60, 15, 16, 16, 16, 16, 16, 16, 15, 38, 16,
+        16, 16, 15, 1, 16, 16, 16, 16, 16, 16, 162, 111, 107, 99, 91, 112, 57, 64, 94, 100, 60,
+        111, 108, 47, 62, 127, 60, 108, 73, 62, 125, 109, 121, 102, 99, 122, 110, 102, 114, 98, 60,
+        97, 32, 104, 114, 101, 102, 61, 98, 111, 103, 32, 105, 100, 61, 100, 62, 60, 111, 15, 15,
+        15, 15, 15, 15, 15, 39, 15, 15, 15, 106, 102, 59, 99, 32, 32, 32, 86, 102, 122, 110, 104,
+        93, 108, 71, 114, 117, 110, 100, 96, 121, 57, 60, 107, 116, 109, 247, 62, 60, 32, 60, 122,
+        98, 99, 98, 97, 32, 119, 127, 127, 62, 60, 112, 62, 121, 116, 60, 47, 116, 100, 62, 62, 60,
+        111, 98, 62, 123, 110, 109, 97, 101, 105, 119, 60, 112, 101, 101, 122, 102, 63, 120, 97,
+        62, 60, 101, 62, 60, 120, 109, 112, 32, 28, 52, 55, 50, 50, 49, 52, 185, 150, 99, 62, 255,
+        112, 76, 85, 60, 112, 62, 73, 100, 116, 116, 60, 75, 50, 73, 116, 120, 110, 127, 255, 118,
+        32, 42, 40, 49, 33, 112, 32, 36, 107, 57, 60, 5, 163, 62, 49, 55, 32, 33, 118, 99, 63, 60,
+        109, 107, 43, 119, 100, 62, 60, 104, 58, 101, 163, 163, 163, 163, 220, 220, 220, 220, 220,
+        220, 220, 220, 220, 220, 220, 220, 1, 107, 117, 107, 108, 44, 102, 58, 60, 116, 101, 97,
+        106, 98, 59, 60, 115, 109, 52, 58, 115, 98, 62, 232, 110, 114, 32, 60, 117, 93, 120, 112,
+        119, 111, 59, 98, 120, 61, 206, 19, 61, 206, 19, 59, 1, 110, 102, 60, 115, 0, 242, 64, 203,
+        8, 111, 50, 59, 121, 122, 32, 42, 35, 32, 37, 101, 120, 104, 121, 0, 242, 59, 63, 121, 231,
+        130, 130, 130, 170, 170, 1, 32, 0, 0, 0, 28, 134, 200, 90, 119, 48, 60, 111, 108, 118, 119,
+        116, 113, 59, 100, 60, 117, 43, 110, 99, 9, 216, 157, 137, 216, 157, 246, 167, 62, 60, 104,
+        61, 43, 28, 134, 200, 105, 119, 48, 60, 122, 110, 0, 242, 61, 61, 114, 231, 130, 130, 130,
+        170, 170, 170, 233, 222, 222, 162, 163, 163, 163, 163, 163, 163, 163, 85, 100, 116, 99, 61,
+        60, 163, 163, 163, 163, 163, 220, 220, 1, 109, 112, 105, 10, 59, 105, 220, 215, 10, 59,
+        122, 100, 100, 121, 97, 43, 43, 43, 102, 122, 100, 60, 62, 114, 116, 122, 115, 61, 60, 115,
+        101, 62, 215, 215, 215, 215, 215, 98, 59, 60, 109, 120, 57, 60, 97, 102, 113, 229, 43, 43,
+        43, 43, 43, 43, 43, 43, 43, 35, 43, 43, 101, 58, 60, 116, 98, 101, 107, 98, 43, 43, 43, 43,
+        43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43, 43,
+        43, 43, 43, 43, 43, 98, 99, 62, 60, 112, 102, 59, 124, 107, 111, 97, 98, 108, 118, 60, 116,
+        102, 101, 104, 97, 62, 60, 255, 127, 46, 60, 116, 101, 62, 60, 105, 102, 63, 116, 116, 60,
+        47, 116, 101, 62, 62, 60, 115, 98, 62, 123, 109, 108, 97, 100, 119, 118, 60, 111, 99, 97,
+        103, 99, 62, 60, 255, 127, 46, 60, 103, 99, 62, 60, 116, 98, 63, 60, 101, 62, 60, 109, 109,
+        231, 130, 130, 130, 213, 213, 213, 233, 222, 222, 59, 101, 103, 58, 60, 100, 111, 61, 65,
+        114, 104, 60, 47, 101, 109, 62, 60, 99, 99, 172, 97, 97, 58, 60, 119, 99, 64, 126, 118,
+        104, 100, 100, 107, 105, 60, 120, 98, 255, 255, 255, 0, 60, 255, 127, 46, 60, 113, 127,
+    ];
     let _local0 = crate::parse(&data[..]).unwrap();
     let d1 = TrivialDecorator::new();
     let _local1 = crate::RenderTree::render(_local0, 1, d1);
@@ -1847,54 +1860,85 @@ fn test_superscript() {
 fn test_header_overflow() {
     let html_hdr = br#"<blockquote><h3>Foo</h3></blockquote>"#;
     test_html(html_hdr, "> ### Foo\n", 20);
-    test_html_conf(html_hdr, "> ### F\n> ### o\n> ### o\n", 7, |c| c.min_wrap_width(1));
+    test_html_conf(html_hdr, "> ### F\n> ### o\n> ### o\n", 7, |c| {
+        c.min_wrap_width(1)
+    });
     test_html_err_conf(html_hdr, Error::TooNarrow, 6, |c| c.min_wrap_width(1));
     test_html_err_conf(html_hdr, Error::TooNarrow, 7, |c| c.min_wrap_width(3));
-    test_html_conf(html_hdr, "> ### F\n> ### o\n> ### o\n", 6, |c| c.min_wrap_width(1).allow_width_overflow());
-    test_html_conf(html_hdr, "> ### Foo\n", 7, |c| c.min_wrap_width(3).allow_width_overflow());
+    test_html_conf(html_hdr, "> ### F\n> ### o\n> ### o\n", 6, |c| {
+        c.min_wrap_width(1).allow_width_overflow()
+    });
+    test_html_conf(html_hdr, "> ### Foo\n", 7, |c| {
+        c.min_wrap_width(3).allow_width_overflow()
+    });
 }
 
 #[test]
 fn test_blockquote_overflow() {
     let html_hdr = br#"<blockquote><blockquote>Foo</blockquote></blockquote>"#;
     test_html(html_hdr, "> > Foo\n", 20);
-    test_html_conf(html_hdr, "> > F\n> > o\n> > o\n", 5, |c| c.min_wrap_width(1));
+    test_html_conf(html_hdr, "> > F\n> > o\n> > o\n", 5, |c| {
+        c.min_wrap_width(1)
+    });
     test_html_err_conf(html_hdr, Error::TooNarrow, 3, |c| c.min_wrap_width(1));
     test_html_err_conf(html_hdr, Error::TooNarrow, 4, |c| c.min_wrap_width(3));
-    test_html_conf(html_hdr, "> > F\n> > o\n> > o\n", 3, |c| c.min_wrap_width(1).allow_width_overflow());
-    test_html_conf(html_hdr, "> > Foo\n", 4, |c| c.min_wrap_width(3).allow_width_overflow());
+    test_html_conf(html_hdr, "> > F\n> > o\n> > o\n", 3, |c| {
+        c.min_wrap_width(1).allow_width_overflow()
+    });
+    test_html_conf(html_hdr, "> > Foo\n", 4, |c| {
+        c.min_wrap_width(3).allow_width_overflow()
+    });
 }
 
 #[test]
 fn test_ul_overflow() {
     let html_hdr = br#"<ul><li><ul><li>Foo</li></ul></li></ul>"#;
     test_html(html_hdr, "* * Foo\n", 20);
-    test_html_conf(html_hdr, "* * F\n    o\n    o\n", 5, |c| c.min_wrap_width(1));
+    test_html_conf(html_hdr, "* * F\n    o\n    o\n", 5, |c| {
+        c.min_wrap_width(1)
+    });
     test_html_err_conf(html_hdr, Error::TooNarrow, 3, |c| c.min_wrap_width(1));
     test_html_err_conf(html_hdr, Error::TooNarrow, 4, |c| c.min_wrap_width(3));
-    test_html_conf(html_hdr, "* * F\n    o\n    o\n", 3, |c| c.min_wrap_width(1).allow_width_overflow());
-    test_html_conf(html_hdr, "* * Foo\n", 4, |c| c.min_wrap_width(3).allow_width_overflow());
+    test_html_conf(html_hdr, "* * F\n    o\n    o\n", 3, |c| {
+        c.min_wrap_width(1).allow_width_overflow()
+    });
+    test_html_conf(html_hdr, "* * Foo\n", 4, |c| {
+        c.min_wrap_width(3).allow_width_overflow()
+    });
 }
 
 #[test]
 fn test_ol_overflow() {
     let html_hdr = br#"<ol><li><ol><li>Foo</li></ol></li></ol>"#;
     test_html(html_hdr, "1. 1. Foo\n", 20);
-    test_html_conf(html_hdr, "1. 1. F\n      o\n      o\n", 7, |c| c.min_wrap_width(1));
+    test_html_conf(html_hdr, "1. 1. F\n      o\n      o\n", 7, |c| {
+        c.min_wrap_width(1)
+    });
     test_html_err_conf(html_hdr, Error::TooNarrow, 5, |c| c.min_wrap_width(1));
     test_html_err_conf(html_hdr, Error::TooNarrow, 6, |c| c.min_wrap_width(3));
-    test_html_conf(html_hdr, "1. 1. F\n      o\n      o\n", 5, |c| c.min_wrap_width(1).allow_width_overflow());
-    test_html_conf(html_hdr, "1. 1. Foo\n", 6, |c| c.min_wrap_width(3).allow_width_overflow());
+    test_html_conf(html_hdr, "1. 1. F\n      o\n      o\n", 5, |c| {
+        c.min_wrap_width(1).allow_width_overflow()
+    });
+    test_html_conf(html_hdr, "1. 1. Foo\n", 6, |c| {
+        c.min_wrap_width(3).allow_width_overflow()
+    });
 }
 
 #[test]
 fn test_dd_overflow() {
     let html_hdr = br#"<blockquote><dl><dt>Foo</dt><dd>Hello</dd></dl></blockquote>"#;
     test_html(html_hdr, "> *Foo*\n>   Hello\n", 20);
-    test_html_conf(html_hdr, "> *Fo\n> o*\n>   H\n>   e\n>   l\n>   l\n>   o\n", 5, |c| c.min_wrap_width(1));
+    test_html_conf(
+        html_hdr,
+        "> *Fo\n> o*\n>   H\n>   e\n>   l\n>   l\n>   o\n",
+        5,
+        |c| c.min_wrap_width(1),
+    );
     test_html_err_conf(html_hdr, Error::TooNarrow, 3, |c| c.min_wrap_width(1));
     test_html_err_conf(html_hdr, Error::TooNarrow, 4, |c| c.min_wrap_width(3));
-    test_html_conf(html_hdr, "> *Foo*\n>   Hel\n>   lo\n", 4, |c| c.min_wrap_width(3).allow_width_overflow());
+    test_html_conf(html_hdr, "> *Foo*\n>   Hel\n>   lo\n", 4, |c| {
+        c.min_wrap_width(3).allow_width_overflow()
+    });
 }
 
 #[test]
@@ -1902,58 +1946,68 @@ fn test_overflow_wide_char() {
     // The smiley is a width-2 character.
     let html = "😃".as_bytes();
     test_html_err_conf(html, Error::TooNarrow, 1, |c| c.min_wrap_width(1));
-    test_html_conf(html, "😃\n", 1, |c| c.min_wrap_width(1).allow_width_overflow());
+    test_html_conf(html, "😃\n", 1, |c| {
+        c.min_wrap_width(1).allow_width_overflow()
+    });
 }
 #[cfg(feature = "css")]
 mod css_tests {
-    use super::{test_html_css, test_html_style, test_html_coloured};
+    use super::{test_html_coloured, test_html_css, test_html_style};
 
     #[test]
     fn test_disp_none() {
-        test_html_css(br#"
+        test_html_css(
+            br#"
           <style>
               .hide { display: none; }
           </style>
         <p>Hello</p>
         <p class="hide">Ignore</p>
         <p>There</p>"#,
-        r#"Hello
+            r#"Hello
 
 There
-"#, 20);
+"#,
+            20,
+        );
 
         // Same as above, but style supplied separately.
-        test_html_style(br#"
+        test_html_style(
+            br#"
         <p>Hello</p>
         <p class="hide">Ignore</p>
         <p>There</p>"#,
-        " .hide { display: none; }",
-        r#"Hello
+            " .hide { display: none; }",
+            r#"Hello
 
 There
-"#, 20);
+"#,
+            20,
+        );
     }
 
     #[test]
-    fn test_selector_elementname()
-    {
-        test_html_css(br#"
+    fn test_selector_elementname() {
+        test_html_css(
+            br#"
           <style>
               div { display: none; }
           </style>
         <p>Hello</p>
         <div>Ignore</div>
         <p>There</p>"#,
-        r#"Hello
+            r#"Hello
 
 There
-"#, 20);
+"#,
+            20,
+        );
     }
 
     #[test]
-    fn test_selector_aoc()
-    {
-        test_html_css(br#"
+    fn test_selector_aoc() {
+        test_html_css(
+            br#"
           <style>
               .someclass > * > span > span {
                   display: none;
@@ -1969,7 +2023,7 @@ There
         </div>
         </div>
         <p>There</p>"#,
-        r#"Hello
+            r#"Hello
 
 Ok
 
@@ -1978,13 +2032,15 @@ Span1
 Span1
 
 There
-"#, 20);
+"#,
+            20,
+        );
     }
 
     #[test]
-    fn test_coloured_a()
-    {
-        test_html_coloured(br##"
+    fn test_coloured_a() {
+        test_html_coloured(
+            br##"
           <style>
               .red {
                   color:#FF0000;
@@ -1992,14 +2048,16 @@ There
           </style>
         <p>Test <a class="red" href="foo">red</a></p>
         "##,
-        r#"Test <R>red</R>
-"#, 20);
+            r#"Test <R>red</R>
+"#,
+            20,
+        );
     }
 
     #[test]
-    fn test_bgcoloured()
-    {
-        test_html_coloured(br##"
+    fn test_bgcoloured() {
+        test_html_coloured(
+            br##"
           <style>
               .red {
                   color:#FF0000;
@@ -2008,14 +2066,16 @@ There
           </style>
         <p>Test <span class="red">red</span></p>
         "##,
-        r#"Test <g><R>red</R></g>
-"#, 20);
+            r#"Test <g><R>red</R></g>
+"#,
+            20,
+        );
     }
 
     #[test]
-    fn test_bgcoloured2()
-    {
-        test_html_coloured(br##"
+    fn test_bgcoloured2() {
+        test_html_coloured(
+            br##"
           <style>
               .red {
                   color:#FF0000;
@@ -2024,14 +2084,16 @@ There
           </style>
         <p>Test <span class="red">red</span> and <span style="color: #00ff00">green</span></p>
         "##,
-        r#"Test <g><R>red</R></g> and <G>green</G>
-"#, 20);
+            r#"Test <g><R>red</R></g> and <G>green</G>
+"#,
+            20,
+        );
     }
 
     #[test]
-    fn test_coloured_element()
-    {
-        test_html_coloured(br##"
+    fn test_coloured_element() {
+        test_html_coloured(
+            br##"
           <style>
               .red {
                   color:#FF0000;
@@ -2039,24 +2101,28 @@ There
           </style>
         <p>Test <blah class="red" href="foo">red</blah></p>
         "##,
-        r#"Test <R>red</R>
-"#, 20);
+            r#"Test <R>red</R>
+"#,
+            20,
+        );
     }
 
     #[test]
-    fn test_color_attr()
-    {
-        test_html_coloured(br##"
+    fn test_color_attr() {
+        test_html_coloured(
+            br##"
         <p>Test <font color="red">red</font></p>
         "##,
-        r#"Test <R>red</R>
-"#, 20);
+            r#"Test <R>red</R>
+"#,
+            20,
+        );
     }
 
     #[test]
-    fn test_css_lists()
-    {
-        test_html_coloured(br##"
+    fn test_css_lists() {
+        test_html_coloured(
+            br##"
           <style>
               .red {
                   color:#FF0000;
@@ -2067,10 +2133,13 @@ There
           <li>Line <span class="red">two</span></li>
         </ul>
         "##,
-        r#"* <R>Line one</R>
+            r#"* <R>Line one</R>
 * Line <R>two</R>
-"#, 20);
-        test_html_coloured(br##"
+"#,
+            20,
+        );
+        test_html_coloured(
+            br##"
           <style>
               .red {
                   color:#FF0000;
@@ -2081,61 +2150,83 @@ There
           <li>Line <span class="red">two</span></li>
         </ul>
         "##,
-        r#"1. <R>Line one</R>
+            r#"1. <R>Line one</R>
 2. Line <R>two</R>
-"#, 20);
+"#,
+            20,
+        );
     }
 
     #[test]
-    fn test_coloured_multi()
-    {
+    fn test_coloured_multi() {
         use super::test_colour_map;
-        let config = crate::config::rich()
-                    .use_doc_css();
-        let dom = config.parse_html(&br##"
+        let config = crate::config::rich().use_doc_css();
+        let dom = config
+            .parse_html(
+                &br##"
           <style>
               .red {
                   color:#FF0000;
               }
           </style>
         <p>Test paragraph with <span class="red">red</span> text</p>
-        "##[..]).unwrap();
+        "##[..],
+            )
+            .unwrap();
         let rt = config.dom_to_render_tree(&dom).unwrap();
-        assert_eq!(config.render_coloured(rt.clone(), 10, test_colour_map).unwrap(),
-        r#"Test
+        assert_eq!(
+            config
+                .render_coloured(rt.clone(), 10, test_colour_map)
+                .unwrap(),
+            r#"Test
 paragraph
 with <R>red</R>
 text
-"#);
-        assert_eq!(config.render_coloured(rt.clone(), 100, test_colour_map).unwrap(),
-        r#"Test paragraph with <R>red</R> text
-"#);
+"#
+        );
+        assert_eq!(
+            config
+                .render_coloured(rt.clone(), 100, test_colour_map)
+                .unwrap(),
+            r#"Test paragraph with <R>red</R> text
+"#
+        );
     }
 
     #[test]
-    fn test_coloured_important()
-    {
+    fn test_coloured_important() {
         use super::test_colour_map;
-        let config = crate::config::rich()
-                    .use_doc_css();
-        let dom = config.parse_html(&br##"
+        let config = crate::config::rich().use_doc_css();
+        let dom = config
+            .parse_html(
+                &br##"
           <style>
               .red {
                   color:#FF0000 !important;
               }
           </style>
         <p>Test paragraph with <span class="red">red</span> text</p>
-        "##[..]).unwrap();
+        "##[..],
+            )
+            .unwrap();
         let rt = config.dom_to_render_tree(&dom).unwrap();
-        assert_eq!(config.render_coloured(rt.clone(), 10, test_colour_map).unwrap(),
-        r#"Test
+        assert_eq!(
+            config
+                .render_coloured(rt.clone(), 10, test_colour_map)
+                .unwrap(),
+            r#"Test
 paragraph
 with <R>red</R>
 text
-"#);
-        assert_eq!(config.render_coloured(rt.clone(), 100, test_colour_map).unwrap(),
-        r#"Test paragraph with <R>red</R> text
-"#);
+"#
+        );
+        assert_eq!(
+            config
+                .render_coloured(rt.clone(), 100, test_colour_map)
+                .unwrap(),
+            r#"Test paragraph with <R>red</R> text
+"#
+        );
     }
 
     #[test]
@@ -2143,39 +2234,17 @@ text
         let html = br#"<head><style>em { color: white; }</style></head>
             <body>
                 Hello *<em>there</em>* boo"#;
-        test_html_coloured(html,
-                  "Hello *<W>there</W>* boo\n",
-                  20);
-        test_html_coloured(html,
-                  "Hello *<W>there</W>*\nboo\n",
-                  15);
-        test_html_coloured(html,
-                  "Hello *<W>there</W>*\nboo\n",
-                  14);
-        test_html_coloured(html,
-                  "Hello *<W>there</W>*\nboo\n",
-                  13);
-        test_html_coloured(html,
-                  "Hello\n*<W>there</W>* boo\n",
-                  12);
-        test_html_coloured(html,
-                  "Hello\n*<W>there</W>* boo\n",
-                  11);
-        test_html_coloured(html,
-                  "Hello\n*<W>there</W>*\nboo\n",
-                  10);
-        test_html_coloured(html,
-                  "Hello\n*<W>there</W>*\nboo\n",
-                  7);
-        test_html_coloured(html,
-                  "Hello\n*<W>there</W>\n* boo\n",
-                  6);
-        test_html_coloured(html,
-                  "Hello\n*<W>ther</W>\n<W>e</W>*\nboo\n",
-                  5);
-        test_html_coloured(html,
-                  "Hell\no\n*<W>the</W>\n<W>re</W>*\nboo\n",
-                  4);
+        test_html_coloured(html, "Hello *<W>there</W>* boo\n", 20);
+        test_html_coloured(html, "Hello *<W>there</W>*\nboo\n", 15);
+        test_html_coloured(html, "Hello *<W>there</W>*\nboo\n", 14);
+        test_html_coloured(html, "Hello *<W>there</W>*\nboo\n", 13);
+        test_html_coloured(html, "Hello\n*<W>there</W>* boo\n", 12);
+        test_html_coloured(html, "Hello\n*<W>there</W>* boo\n", 11);
+        test_html_coloured(html, "Hello\n*<W>there</W>*\nboo\n", 10);
+        test_html_coloured(html, "Hello\n*<W>there</W>*\nboo\n", 7);
+        test_html_coloured(html, "Hello\n*<W>there</W>\n* boo\n", 6);
+        test_html_coloured(html, "Hello\n*<W>ther</W>\n<W>e</W>*\nboo\n", 5);
+        test_html_coloured(html, "Hell\no\n*<W>the</W>\n<W>re</W>*\nboo\n", 4);
         test_html_coloured(html,
                   "H\ne\nl\nl\no\n*<W></W>\n<W>t</W>\n<W>h</W>\n<W>e</W>\n<W>r</W>\n<W>e</W>\n*\nb\no\no\n",
                   1);


### PR DESCRIPTION
A raw mode was requested in #53

I'm also in need of this, as well as a mode that simply does not draw borders. The difference between the two is that raw mode can be used as input to a full text index, as it respects locality of words, words that are inside one cell should be adjacent in the input to a search index.

I don't quite get how this works with deeply nested tables (see deeply_nested test), but think this could benefit from your input at this stage.