### PR TITLE
Add --ignore-css-colour option to html2text example.

### DIFF
--- a/examples/html2text.rs
+++ b/examples/html2text.rs
@@ -111,8 +111,9 @@ where
             #[cfg(not(feature = "css"))]
             let use_css_colours = false;
             return conf
-                .coloured(input, flags.width,
-                          move |anns, s| default_colour_map(anns, s, use_css_colours))
+                .coloured(input, flags.width, move |anns, s| {
+                    default_colour_map(anns, s, use_css_colours)
+                })
                 .unwrap();
         }
     }

--- a/examples/html2text.rs
+++ b/examples/html2text.rs
@@ -10,7 +10,7 @@ use std::io::Write;
 #[cfg(unix)]
 use html2text::render::text_renderer::RichAnnotation;
 #[cfg(unix)]
-fn default_colour_map(annotations: &[RichAnnotation], s: &str) -> String {
+fn default_colour_map(annotations: &[RichAnnotation], s: &str, use_css_colours: bool) -> String {
     use termion::color::*;
     use RichAnnotation::*;
     // Explicit CSS colours override any other colours
@@ -60,13 +60,17 @@ fn default_colour_map(annotations: &[RichAnnotation], s: &str) -> String {
                 }
             }
             Colour(c) => {
-                start.push(format!("{}", Fg(Rgb(c.r, c.g, c.b))));
-                finish.push(format!("{}", Fg(Reset)));
-                have_explicit_colour = true;
+                if use_css_colours {
+                    start.push(format!("{}", Fg(Rgb(c.r, c.g, c.b))));
+                    finish.push(format!("{}", Fg(Reset)));
+                    have_explicit_colour = true;
+                }
             }
             BgColour(c) => {
-                start.push(format!("{}", Bg(Rgb(c.r, c.g, c.b))));
-                finish.push(format!("{}", Bg(Reset)));
+                if use_css_colours {
+                    start.push(format!("{}", Bg(Rgb(c.r, c.g, c.b))));
+                    finish.push(format!("{}", Bg(Reset)));
+                }
             }
             _ => {}
         }
@@ -102,8 +106,13 @@ where
         if flags.use_colour {
             let conf = config::rich();
             let conf = update_config(conf, &flags);
+            #[cfg(feature = "css")]
+            let use_css_colours = !flags.ignore_css_colours;
+            #[cfg(not(feature = "css"))]
+            let use_css_colours = false;
             return conf
-                .coloured(input, flags.width, default_colour_map)
+                .coloured(input, flags.width,
+                          move |anns, s| default_colour_map(anns, s, use_css_colours))
                 .unwrap();
         }
     }
@@ -125,6 +134,8 @@ struct Flags {
     use_colour: bool,
     #[cfg(feature = "css")]
     use_css: bool,
+    #[cfg(feature = "css")]
+    ignore_css_colours: bool,
 }
 
 fn main() {
@@ -139,6 +150,8 @@ fn main() {
         use_colour: false,
         #[cfg(feature = "css")]
         use_css: false,
+        #[cfg(feature = "css")]
+        ignore_css_colours: false,
     };
     let mut literal: bool = false;
 
@@ -178,6 +191,9 @@ fn main() {
         #[cfg(feature = "css")]
         ap.refer(&mut flags.use_css)
             .add_option(&["--css"], StoreTrue, "Enable CSS");
+        #[cfg(feature = "css")]
+        ap.refer(&mut flags.ignore_css_colours)
+            .add_option(&["--ignore-css-colour"], StoreTrue, "With --css, ignore CSS colour information (still hides elements with e.g. display: none)");
         ap.parse_args_or_exit();
     }
 


### PR DESCRIPTION
This lets you enable CSS for the `display: none` and similar handling while still using the default colours added for <strong> etc.

Fixes #138.