### PR TITLE
Flatten pub exported paths

### DIFF
--- a/examples/html2term.rs
+++ b/examples/html2term.rs
@@ -10,7 +10,7 @@ mod top {
     use ::std;
     use ::termion;
     use argparse::{ArgumentParser, Store};
-    use html2text::render::text_renderer::{RichAnnotation, TaggedLine, TaggedLineElement};
+    use html2text::render::{RichAnnotation, TaggedLine, TaggedLineElement};
     use std::collections::HashMap;
     use std::io::{self, Write};
     use termion::cursor::Goto;

--- a/examples/html2text.rs
+++ b/examples/html2text.rs
@@ -2,13 +2,13 @@ extern crate argparse;
 extern crate html2text;
 use argparse::{ArgumentParser, Store, StoreOption, StoreTrue};
 use html2text::config::{self, Config};
-use html2text::render::text_renderer::{TextDecorator, TrivialDecorator};
+use html2text::render::{TextDecorator, TrivialDecorator};
 use log::trace;
 use std::io;
 use std::io::Write;
 
 #[cfg(unix)]
-use html2text::render::text_renderer::RichAnnotation;
+use html2text::render::RichAnnotation;
 #[cfg(unix)]
 fn default_colour_map(
     annotations: &[RichAnnotation],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,10 +67,12 @@ pub mod css;
 pub mod render;
 
 use render::text_renderer::{
-    PlainDecorator, RenderLine, RenderOptions, RichAnnotation, RichDecorator, SubRenderer,
-    TaggedLine, TextDecorator, TextRenderer,
+    RenderLine, RenderOptions, RichAnnotation, SubRenderer, TaggedLine, TextRenderer,
 };
+use render::PlainDecorator;
 use render::Renderer;
+use render::RichDecorator;
+use render::TextDecorator;
 
 use html5ever::driver::ParseOpts;
 use html5ever::parse_document;

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -4,7 +4,12 @@
 use crate::Colour;
 use crate::Error;
 
-pub mod text_renderer;
+pub(crate) mod text_renderer;
+
+pub use text_renderer::{
+    PlainDecorator, RichAnnotation, RichDecorator, TaggedLine, TaggedLineElement, TextDecorator,
+    TrivialDecorator,
+};
 
 /// A type which is a backend for HTML to text rendering.
 pub(crate) trait Renderer {

--- a/src/render/text_renderer.rs
+++ b/src/render/text_renderer.rs
@@ -885,7 +885,7 @@ impl<T: PartialEq + Eq + Clone + Debug + Default> RenderLine<T> {
 #[derive(Clone)]
 pub(crate) struct SubRenderer<D: TextDecorator> {
     /// Text width
-    pub width: usize,
+    width: usize,
     /// Rendering options
     pub options: RenderOptions,
     lines: LinkedList<RenderLine<Vec<D::Annotation>>>,


### PR DESCRIPTION
The main imports needed from this crate are behind extra modules, this flattens the externally visible module hierarchy to `html2text::render::{..}`