### PR TITLE
Fix issue 155: table rows with styling going missing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Possible log types:
 - `[fixed]` for any bug fixes.
 - `[security]` to invite users to upgrade in case of vulnerabilities.
 
+### 0.13.0-alpha.1
+
+- [fixed] Table rows with colours would disappear. (thanks tkapias)
+
 ### 0.13.0-alpha.0
 
 - [changed] Replaced LightningCSS with a smaller CSS parser.  There is a chance

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "html2text"
-version = "0.13.0-alpha.0"
+version = "0.13.0-alpha.1"
 authors = ["Chris Emerson <github@mail.nosreme.org>"]
 description = "Render HTML as plain text."
 repository = "https://github.com/jugglerchris/rust-html2text/"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -892,6 +892,20 @@ impl<'a, C: 'a, N> TreeMapResult<'a, C, N, RenderNode> {
                                     cellinfo.content = vec![wrapped];
                                     RenderNode::new(RenderNodeInfo::TableCell(cellinfo))
                                 }
+                                RenderNodeInfo::TableRow(mut row, vert) => {
+                                    let cells = row.cells;
+                                    let cells = cells
+                                        .into_iter()
+                                        .map(|mut child| {
+                                            let children = child.content;
+                                            let wrapped = RenderNode::new(f(children));
+                                            child.content = vec![wrapped];
+                                            child
+                                        })
+                                        .collect();
+                                    row.cells = cells;
+                                    RenderNode::new(RenderNodeInfo::TableRow(row, vert))
+                                }
                                 ni => RenderNode::new(f(vec![RenderNode::new(ni)])),
                             }
                         }))

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -58,9 +58,6 @@ pub(crate) trait Renderer {
     /// Return the current width in character cells
     fn width(&self) -> usize;
 
-    /// Add a line to the current block without starting a new one.
-    fn add_block_line(&mut self, line: &str);
-
     /// Add a new block from a sub renderer, and prefix every line by the
     /// corresponding text from each iteration of prefixes.
     fn append_subrender<'a, I>(&mut self, other: Self, prefixes: I) -> Result<(), Error>
@@ -85,9 +82,6 @@ pub(crate) trait Renderer {
 
     /// Returns true if this renderer has no content.
     fn empty(&self) -> bool;
-
-    /// Return the length of the contained text.
-    fn text_len(&self) -> usize;
 
     /// Start a hyperlink
     /// TODO: return sub-builder or similar to make misuse

--- a/src/render/text_renderer.rs
+++ b/src/render/text_renderer.rs
@@ -993,22 +993,6 @@ impl<D: TextDecorator> SubRenderer<D> {
         }
     }
 
-    /// Add a prerendered (multiline) string with the current annotations.
-    fn add_subblock(&mut self, s: &str) {
-        use self::TaggedLineElement::Str;
-
-        html_trace!("add_subblock({}, {})", self.width, s);
-        let tag = self.ann_stack.clone();
-        self.lines.extend(s.lines().map(|l| {
-            let mut line = TaggedLine::new();
-            line.push(Str(TaggedString {
-                s: l.into(),
-                tag: tag.clone(),
-            }));
-            RenderLine::Text(line)
-        }));
-    }
-
     /// Flushes the current wrapped block into the lines.
     fn flush_wrapping(&mut self) -> Result<(), Error> {
         if let Some(w) = self.wrapping.take() {
@@ -1249,10 +1233,6 @@ impl<D: TextDecorator> Renderer for SubRenderer<D> {
         self.width
     }
 
-    fn add_block_line(&mut self, line: &str) {
-        self.add_subblock(line);
-    }
-
     fn append_subrender<'a, I>(&mut self, other: Self, prefixes: I) -> Result<(), Error>
     where
         I: Iterator<Item = &'a str>,
@@ -1476,20 +1456,6 @@ impl<D: TextDecorator> Renderer for SubRenderer<D> {
             } else {
                 true
             }
-    }
-
-    fn text_len(&self) -> usize {
-        let mut result = 0;
-        for line in &self.lines {
-            result += match *line {
-                RenderLine::Text(ref tline) => tline.width(),
-                RenderLine::Line(_) => 0, // FIXME: should borders count?
-            };
-        }
-        if let Some(ref w) = self.wrapping {
-            result += w.text_len();
-        }
-        result
     }
 
     fn start_link(&mut self, target: &str) -> crate::Result<()> {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2392,4 +2392,36 @@ Baz
             20,
         );
     }
+
+    #[test]
+    fn test_colour_row() {
+        test_html_coloured(
+            br#"<head><style>
+        tr.r {
+            color: #f00;
+        }
+        </style></head><body>
+        <table>
+         <tr>
+           <td>Row</td><td>One</td>
+         </tr>
+         <tr class="r">
+           <td>Row</td><td>Two</td>
+         </tr>
+         <tr>
+           <td>Row</td><td>Three</td>
+         </tr>
+        </table>
+        "#,
+            r#"───┬─────
+Row│One  
+───┼─────
+<R>Row</R>│<R>Two</R>  
+───┼─────
+Row│Three
+───┴─────
+"#,
+            20,
+        );
+    }
 }


### PR DESCRIPTION
There was a missing case in `wrap_render_nodes()`; table row nodes need to wrap the nested contents so that the TableRow nodes are still direct children of the TableBody.

Fixes #155 