### PR TITLE
Add option to disable wrapping links

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1015,6 +1015,7 @@ struct HtmlContext {
     min_wrap_width: usize,
     raw: bool,
     draw_borders: bool,
+    wrap_links: bool,
 }
 
 fn dom_to_render_tree_with_context<T: Write>(
@@ -1912,6 +1913,7 @@ pub mod config {
         min_wrap_width: usize,
         raw: bool,
         draw_borders: bool,
+        wrap_links: bool,
     }
 
     impl<D: TextDecorator> Config<D> {
@@ -1929,6 +1931,7 @@ pub mod config {
                 min_wrap_width: self.min_wrap_width,
                 raw: self.raw,
                 draw_borders: self.draw_borders,
+                wrap_links: self.wrap_links,
             }
         }
         /// Parse with context.
@@ -2086,6 +2089,11 @@ pub mod config {
             self.draw_borders = false;
             self
         }
+        /// Do not wrap links
+        pub fn no_link_wrapping(mut self) -> Self {
+            self.wrap_links = false;
+            self
+        }
     }
 
     impl Config<RichDecorator> {
@@ -2158,6 +2166,7 @@ pub mod config {
             min_wrap_width: MIN_WIDTH,
             raw: false,
             draw_borders: true,
+            wrap_links: true,
         }
     }
 
@@ -2175,6 +2184,7 @@ pub mod config {
             min_wrap_width: MIN_WIDTH,
             raw: false,
             draw_borders: true,
+            wrap_links: true,
         }
     }
 
@@ -2192,6 +2202,7 @@ pub mod config {
             min_wrap_width: MIN_WIDTH,
             raw: false,
             draw_borders: true,
+            wrap_links: true,
         }
     }
 }
@@ -2220,6 +2231,7 @@ impl RenderTree {
             allow_width_overflow: context.allow_width_overflow,
             raw: context.raw,
             draw_borders: context.draw_borders,
+            wrap_links: context.wrap_links,
         };
         let test_decorator = decorator.make_subblock_decorator();
         let builder = SubRenderer::new(width, render_options, decorator);

--- a/src/render/text_renderer.rs
+++ b/src/render/text_renderer.rs
@@ -939,6 +939,9 @@ pub(crate) struct RenderOptions {
 
     /// Whether to draw table borders
     pub draw_borders: bool,
+
+    /// Whether to wrap links as normal text
+    pub wrap_links: bool,
 }
 
 impl Default for RenderOptions {
@@ -949,6 +952,7 @@ impl Default for RenderOptions {
             pad_block_width: Default::default(),
             raw: false,
             draw_borders: true,
+            wrap_links: true,
         }
     }
 }
@@ -1046,7 +1050,7 @@ impl<D: TextDecorator> SubRenderer<D> {
                 let tag = vec![ts.tag];
 
                 let width = s.width();
-                if pos + width > self.width {
+                if self.options.wrap_links && pos + width > self.width {
                     // split the string and start a new line
                     let mut buf = String::new();
                     for c in s.chars() {


### PR DESCRIPTION
Adds an option to disable wrapping of links. This is because wrapping the links breaks auto-linkification in many cases, and some users (including me!) might like to disable it.

The default behaviour remains the same.