### PR TITLE
Support white-space: pre-wrap

### DIFF
--- a/src/css.rs
+++ b/src/css.rs
@@ -267,6 +267,16 @@ pub (crate) enum WhiteSpace {
     // BreakSpaces,
 }
 
+impl WhiteSpace {
+    pub fn preserve_whitespace(&self) -> bool {
+        match self {
+            WhiteSpace::Normal => false,
+            WhiteSpace::Pre |
+            WhiteSpace::PreWrap => true,
+        }
+    }
+}
+
 #[derive(Debug, Copy, Clone, Default)]
 pub(crate) struct ComputedStyle {
     /// The computed foreground colour, if any
@@ -407,7 +417,7 @@ impl StyleData {
                         styles: styles.clone(),
                     };
                     html_trace_quiet!("Adding ruleset {ruleset:?}");
-                    rules.push(ruleset);
+                    rules.push(dbg!(ruleset));
                 }
             }
         }

--- a/src/css.rs
+++ b/src/css.rs
@@ -257,7 +257,7 @@ impl<T: Copy + Clone> Default for WithSpec<T> {
 }
 
 #[derive(Debug, Copy, Clone, Default, PartialEq)]
-pub (crate) enum WhiteSpace {
+pub(crate) enum WhiteSpace {
     #[default]
     Normal,
     // NoWrap,
@@ -271,8 +271,7 @@ impl WhiteSpace {
     pub fn preserve_whitespace(&self) -> bool {
         match self {
             WhiteSpace::Normal => false,
-            WhiteSpace::Pre |
-            WhiteSpace::PreWrap => true,
+            WhiteSpace::Pre | WhiteSpace::PreWrap => true,
         }
     }
 }
@@ -384,8 +383,7 @@ fn styles_from_properties(decls: &[parser::Declaration]) -> Vec<StyleDecl> {
                     style: Style::WhiteSpace(*value),
                     importance: decl.important,
                 });
-            }
-            /*
+            } /*
               _ => {
                   html_trace_quiet!("CSS: Unhandled property {:?}", decl);
               }

--- a/src/css.rs
+++ b/src/css.rs
@@ -10,7 +10,8 @@ use crate::{
         Handle,
         NodeData::{self, Comment, Document, Element},
     },
-    tree_map_reduce, Colour, Result, TreeMapResult,
+    tree_map_reduce, Colour, ComputedStyle, Result, Specificity, StyleOrigin, TreeMapResult,
+    WhiteSpace,
 };
 
 use self::parser::Importance;
@@ -23,43 +24,6 @@ pub(crate) enum SelectorComponent {
     Star,
     CombChild,
     CombDescendant,
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
-pub(crate) struct Specificity {
-    inline: bool,
-    id: u16,
-    class: u16,
-    typ: u16,
-}
-
-impl Specificity {
-    fn inline() -> Self {
-        Specificity {
-            inline: true,
-            id: 0,
-            class: 0,
-            typ: 0,
-        }
-    }
-}
-
-impl PartialOrd for Specificity {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        match self.inline.partial_cmp(&other.inline) {
-            Some(core::cmp::Ordering::Equal) => {}
-            ord => return ord,
-        }
-        match self.id.partial_cmp(&other.id) {
-            Some(core::cmp::Ordering::Equal) => {}
-            ord => return ord,
-        }
-        match self.class.partial_cmp(&other.class) {
-            Some(core::cmp::Ordering::Equal) => {}
-            ord => return ord,
-        }
-        self.typ.partial_cmp(&other.typ)
-    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -183,110 +147,6 @@ pub(crate) enum Style {
 pub(crate) struct StyleDecl {
     style: Style,
     importance: Importance,
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Default, PartialOrd)]
-pub(crate) enum StyleOrigin {
-    #[default]
-    None,
-    Agent,
-    User,
-    Author,
-}
-
-#[derive(Clone, Copy, Debug)]
-pub(crate) struct WithSpec<T: Copy + Clone> {
-    val: Option<T>,
-    origin: StyleOrigin,
-    specificity: Specificity,
-    important: bool,
-}
-impl<T: Copy + Clone> WithSpec<T> {
-    pub(crate) fn maybe_update(
-        &mut self,
-        important: bool,
-        origin: StyleOrigin,
-        specificity: Specificity,
-        val: T,
-    ) {
-        if self.val.is_some() {
-            // We already have a value, so need to check.
-            if self.important && !important {
-                // important takes priority over not important.
-                return;
-            }
-            // importance is the same.  Next is checking the origin.
-            {
-                use StyleOrigin::*;
-                match (self.origin, origin) {
-                    (Agent, Agent) | (User, User) | (Author, Author) => {
-                        // They're the same so continue the comparison
-                    }
-                    (mine, theirs) => {
-                        if (important && theirs > mine) || (!important && mine > theirs) {
-                            return;
-                        }
-                    }
-                }
-            }
-            // We're now from the same origin an importance
-            if specificity < self.specificity {
-                return;
-            }
-        }
-        self.val = Some(val);
-        self.origin = origin;
-        self.specificity = specificity;
-        self.important = important;
-    }
-
-    pub fn val(&self) -> Option<T> {
-        self.val
-    }
-}
-
-impl<T: Copy + Clone> Default for WithSpec<T> {
-    fn default() -> Self {
-        WithSpec {
-            val: None,
-            origin: StyleOrigin::None,
-            specificity: Default::default(),
-            important: false,
-        }
-    }
-}
-
-#[derive(Debug, Copy, Clone, Default, PartialEq)]
-pub(crate) enum WhiteSpace {
-    #[default]
-    Normal,
-    // NoWrap,
-    Pre,
-    PreWrap,
-    // PreLine,
-    // BreakSpaces,
-}
-
-impl WhiteSpace {
-    pub fn preserve_whitespace(&self) -> bool {
-        match self {
-            WhiteSpace::Normal => false,
-            WhiteSpace::Pre | WhiteSpace::PreWrap => true,
-        }
-    }
-}
-
-#[derive(Debug, Copy, Clone, Default)]
-pub(crate) struct ComputedStyle {
-    /// The computed foreground colour, if any
-    pub(crate) colour: WithSpec<Colour>,
-    /// The specificity for colour
-    /// The computed background colour, if any
-    pub(crate) bg_colour: WithSpec<Colour>,
-    /// If set, indicates whether `display: none` or something equivalent applies
-    pub(crate) display_none: WithSpec<bool>,
-    /// The CSS white-space property
-    pub(crate) white_space: WithSpec<WhiteSpace>,
 }
 
 #[derive(Debug, Clone)]
@@ -643,7 +503,7 @@ pub(crate) fn dom_to_stylesheet<T: Write>(handle: Handle, err_out: &mut T) -> Re
 
 #[cfg(test)]
 mod tests {
-    use crate::css::Specificity;
+    use crate::Specificity;
 
     use super::parser::parse_selector;
 

--- a/src/css/parser.rs
+++ b/src/css/parser.rs
@@ -687,7 +687,9 @@ fn parse_display(value: &RawValue) -> Result<Display, nom::Err<nom::error::Error
     Ok(Display::Other)
 }
 
-fn parse_white_space(value: &RawValue) -> Result<WhiteSpace, nom::Err<nom::error::Error<&'static str>>> {
+fn parse_white_space(
+    value: &RawValue,
+) -> Result<WhiteSpace, nom::Err<nom::error::Error<&'static str>>> {
     for tok in &value.tokens {
         if let Token::Ident(word) = tok {
             match word.deref() {

--- a/src/css/parser.rs
+++ b/src/css/parser.rs
@@ -64,6 +64,7 @@ pub enum Display {
 }
 
 #[derive(Debug, PartialEq)]
+#[non_exhaustive]
 pub enum Decl {
     Color {
         value: Colour,
@@ -85,6 +86,9 @@ pub enum Decl {
     },
     Display {
         value: Display,
+    },
+    WhiteSpace {
+        value: WhiteSpace,
     },
     Unknown {
         name: PropertyName,
@@ -161,7 +165,7 @@ pub struct Declaration {
     pub important: Importance,
 }
 
-use super::{Selector, SelectorComponent};
+use super::{Selector, SelectorComponent, WhiteSpace};
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct RuleSet {
@@ -427,6 +431,10 @@ pub fn parse_declaration(text: &str) -> IResult<&str, Option<Declaration>> {
             let value = parse_display(&value)?;
             Decl::Display { value }
         }
+        "white-space" => {
+            let value = parse_white_space(&value)?;
+            Decl::WhiteSpace { value }
+        }
         _ => Decl::Unknown {
             name: prop,
             //            value: /*value*/"".into(),
@@ -677,6 +685,20 @@ fn parse_display(value: &RawValue) -> Result<Display, nom::Err<nom::error::Error
         }
     }
     Ok(Display::Other)
+}
+
+fn parse_white_space(value: &RawValue) -> Result<WhiteSpace, nom::Err<nom::error::Error<&'static str>>> {
+    for tok in &value.tokens {
+        if let Token::Ident(word) = tok {
+            match word.deref() {
+                "normal" => return Ok(WhiteSpace::Normal),
+                "pre" => return Ok(WhiteSpace::Pre),
+                "pre-wrap" => return Ok(WhiteSpace::PreWrap),
+                _ => (),
+            }
+        }
+    }
+    Ok(WhiteSpace::Normal)
 }
 
 pub fn parse_rules(text: &str) -> IResult<&str, Vec<Declaration>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,14 +64,6 @@ mod macros;
 pub mod css;
 pub mod render;
 
-#[cfg(feature = "css")]
-use css::ComputedStyle;
-
-#[cfg(not(feature = "css"))]
-#[derive(Copy, Clone, Debug, Default)]
-struct ComputedStyle;
-
-use css::WhiteSpace;
 use render::text_renderer::{
     RenderLine, RenderOptions, RichAnnotation, SubRenderer, TaggedLine, TextRenderer,
 };
@@ -97,6 +89,27 @@ use std::io;
 use std::io::Write;
 use std::iter::{once, repeat};
 
+#[derive(Debug, Copy, Clone, Default, PartialEq)]
+pub(crate) enum WhiteSpace {
+    #[default]
+    Normal,
+    // NoWrap,
+    Pre,
+    #[allow(unused)]
+    PreWrap,
+    // PreLine,
+    // BreakSpaces,
+}
+
+impl WhiteSpace {
+    pub fn preserve_whitespace(&self) -> bool {
+        match self {
+            WhiteSpace::Normal => false,
+            WhiteSpace::Pre | WhiteSpace::PreWrap => true,
+        }
+    }
+}
+
 /// An RGB colour value
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Colour {
@@ -106,6 +119,132 @@ pub struct Colour {
     pub g: u8,
     /// Blue value
     pub b: u8,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default, PartialOrd)]
+pub(crate) enum StyleOrigin {
+    #[default]
+    None,
+    Agent,
+    #[allow(unused)]
+    User,
+    #[allow(unused)]
+    Author,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+pub(crate) struct Specificity {
+    inline: bool,
+    id: u16,
+    class: u16,
+    typ: u16,
+}
+
+impl Specificity {
+    #[cfg(feature = "css")]
+    fn inline() -> Self {
+        Specificity {
+            inline: true,
+            id: 0,
+            class: 0,
+            typ: 0,
+        }
+    }
+}
+
+impl PartialOrd for Specificity {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        match self.inline.partial_cmp(&other.inline) {
+            Some(core::cmp::Ordering::Equal) => {}
+            ord => return ord,
+        }
+        match self.id.partial_cmp(&other.id) {
+            Some(core::cmp::Ordering::Equal) => {}
+            ord => return ord,
+        }
+        match self.class.partial_cmp(&other.class) {
+            Some(core::cmp::Ordering::Equal) => {}
+            ord => return ord,
+        }
+        self.typ.partial_cmp(&other.typ)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct WithSpec<T: Copy + Clone> {
+    val: Option<T>,
+    origin: StyleOrigin,
+    specificity: Specificity,
+    important: bool,
+}
+impl<T: Copy + Clone> WithSpec<T> {
+    pub(crate) fn maybe_update(
+        &mut self,
+        important: bool,
+        origin: StyleOrigin,
+        specificity: Specificity,
+        val: T,
+    ) {
+        if self.val.is_some() {
+            // We already have a value, so need to check.
+            if self.important && !important {
+                // important takes priority over not important.
+                return;
+            }
+            // importance is the same.  Next is checking the origin.
+            {
+                use StyleOrigin::*;
+                match (self.origin, origin) {
+                    (Agent, Agent) | (User, User) | (Author, Author) => {
+                        // They're the same so continue the comparison
+                    }
+                    (mine, theirs) => {
+                        if (important && theirs > mine) || (!important && mine > theirs) {
+                            return;
+                        }
+                    }
+                }
+            }
+            // We're now from the same origin an importance
+            if specificity < self.specificity {
+                return;
+            }
+        }
+        self.val = Some(val);
+        self.origin = origin;
+        self.specificity = specificity;
+        self.important = important;
+    }
+
+    pub fn val(&self) -> Option<T> {
+        self.val
+    }
+}
+
+impl<T: Copy + Clone> Default for WithSpec<T> {
+    fn default() -> Self {
+        WithSpec {
+            val: None,
+            origin: StyleOrigin::None,
+            specificity: Default::default(),
+            important: false,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, Default)]
+pub(crate) struct ComputedStyle {
+    #[cfg(feature = "css")]
+    /// The computed foreground colour, if any
+    pub(crate) colour: WithSpec<Colour>,
+    #[cfg(feature = "css")]
+    /// The computed background colour, if any
+    pub(crate) bg_colour: WithSpec<Colour>,
+    #[cfg(feature = "css")]
+    /// If set, indicates whether `display: none` or something equivalent applies
+    pub(crate) display_none: WithSpec<bool>,
+    /// The CSS white-space property
+    pub(crate) white_space: WithSpec<WhiteSpace>,
 }
 
 /// Errors from reading or rendering HTML
@@ -1333,7 +1472,7 @@ fn process_dom_node<'a, T: Write>(
                     let mut computed = computed;
                     computed.white_space.maybe_update(
                         false,
-                        css::StyleOrigin::Agent,
+                        StyleOrigin::Agent,
                         Default::default(),
                         WhiteSpace::Pre,
                     );
@@ -1500,12 +1639,13 @@ impl PushedStyleInfo {
     fn apply<D: TextDecorator>(render: &mut TextRenderer<D>, style: &ComputedStyle) -> Self {
         #[allow(unused_mut)]
         let mut result: PushedStyleInfo = Default::default();
-        #[cfg(feature = "css")]
         {
+            #[cfg(feature = "css")]
             if let Some(col) = style.colour.val() {
                 render.push_colour(col);
                 result.colour = true;
             }
+            #[cfg(feature = "css")]
             if let Some(col) = style.bg_colour.val() {
                 render.push_bgcolour(col);
                 result.bgcolour = true;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -531,8 +531,7 @@ impl RenderNode {
             }
 
             Container(ref v) | Em(ref v) | Strong(ref v) | Strikeout(ref v) | Code(ref v)
-            | Block(ref v) | Div(ref v) | Dl(ref v) | Dt(ref v) | ListItem(ref v)
-            | Sup(ref v) => v
+            | Block(ref v) | Div(ref v) | Dl(ref v) | Dt(ref v) | ListItem(ref v) | Sup(ref v) => v
                 .iter()
                 .map(recurse)
                 .fold(Default::default(), SizeEstimate::add),
@@ -1332,7 +1331,12 @@ fn process_dom_node<'a, T: Write>(
                 }),
                 expanded_name!(html "pre") => pending(input, move |_, cs| {
                     let mut computed = computed;
-                    computed.white_space.maybe_update(false, css::StyleOrigin::Agent, Default::default(), WhiteSpace::Pre);
+                    computed.white_space.maybe_update(
+                        false,
+                        css::StyleOrigin::Agent,
+                        Default::default(),
+                        WhiteSpace::Pre,
+                    );
                     Ok(Some(RenderNode::new_styled(Block(cs), computed)))
                 }),
                 expanded_name!(html "br") => Finished(RenderNode::new_styled(Break, computed)),
@@ -1508,9 +1512,8 @@ impl PushedStyleInfo {
             }
             if let Some(ws) = style.white_space.val() {
                 match ws {
-                    WhiteSpace::Normal => {},
-                    WhiteSpace::Pre |
-                    WhiteSpace::PreWrap => {
+                    WhiteSpace::Normal => {}
+                    WhiteSpace::Pre | WhiteSpace::PreWrap => {
                         render.push_ws(ws);
                         result.white_space = true;
                     }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,6 +1,7 @@
 //! Module containing the `Renderer` interface for constructing a
 //! particular text output.
 
+use crate::css::WhiteSpace;
 use crate::Colour;
 use crate::Error;
 
@@ -45,11 +46,11 @@ pub(crate) trait Renderer {
     }
 
     /// Begin a preformatted block.  Until the corresponding end,
-    /// whitespace will used verbatim.  Pre regions can nest.
-    fn start_pre(&mut self);
+    /// whitespace handlinng will be modified.  Can be nested.
+    fn push_ws(&mut self, ws: WhiteSpace);
 
-    /// Finish a preformatted block started with `start_pre`.
-    fn end_pre(&mut self);
+    /// Finish a preformatted block started with `push_ws`.
+    fn pop_ws(&mut self);
 
     /// Add some inline text (which should be wrapped at the
     /// appropriate width) to the current block.

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,9 +1,9 @@
 //! Module containing the `Renderer` interface for constructing a
 //! particular text output.
 
-use crate::css::WhiteSpace;
 use crate::Colour;
 use crate::Error;
+use crate::WhiteSpace;
 
 pub(crate) mod text_renderer;
 

--- a/src/render/text_renderer.rs
+++ b/src/render/text_renderer.rs
@@ -3,9 +3,9 @@
 //! This module implements helpers and concrete types for rendering from HTML
 //! into different text formats.
 
-use crate::css::WhiteSpace;
 use crate::Colour;
 use crate::Error;
+use crate::WhiteSpace;
 
 use super::Renderer;
 use std::cell::Cell;

--- a/src/render/text_renderer.rs
+++ b/src/render/text_renderer.rs
@@ -3,6 +3,7 @@
 //! This module implements helpers and concrete types for rendering from HTML
 //! into different text formats.
 
+use crate::css::WhiteSpace;
 use crate::Colour;
 use crate::Error;
 
@@ -332,7 +333,7 @@ impl<T: Clone + Eq + Debug + Default> WrappedBlock<T> {
         }
     }
 
-    fn flush_word(&mut self) -> Result<(), Error> {
+    fn flush_word(&mut self, with_space: bool) -> Result<(), Error> {
         use self::TaggedLineElement::Str;
 
         /* Finish the word. */
@@ -343,7 +344,7 @@ impl<T: Clone + Eq + Debug + Default> WrappedBlock<T> {
             let space_needed = self.wordlen + if self.linelen > 0 { 1 } else { 0 }; // space
             if space_needed <= space_in_line {
                 html_trace!("Got enough space");
-                if self.linelen > 0 {
+                if self.linelen > 0 && with_space {
                     self.line.push(Str(TaggedString {
                         s: " ".into(),
                         tag: self.spacetag.clone().unwrap_or_else(|| Default::default()),
@@ -458,7 +459,7 @@ impl<T: Clone + Eq + Debug + Default> WrappedBlock<T> {
     }
 
     fn flush(&mut self) -> Result<(), Error> {
-        self.flush_word()?;
+        self.flush_word(true)?;
         self.flush_line();
         Ok(())
     }
@@ -492,7 +493,7 @@ impl<T: Clone + Eq + Debug + Default> WrappedBlock<T> {
         for c in text.chars() {
             if c.is_whitespace() {
                 /* Whitespace is mostly ignored, except to terminate words. */
-                self.flush_word()?;
+                self.flush_word(true)?;
                 self.spacetag = Some(tag.clone());
             } else if let Some(charwidth) = UnicodeWidthChar::width(c) {
                 /* Not whitespace; add to the current word. */
@@ -518,7 +519,7 @@ impl<T: Clone + Eq + Debug + Default> WrappedBlock<T> {
         );
         // Make sure that any previous word has been sent to the line, as we
         // bypass the word buffer.
-        self.flush_word()?;
+        self.flush_word(true)?;
 
         for c in text.chars() {
             if let Some(charwidth) = UnicodeWidthChar::width(c) {
@@ -565,6 +566,59 @@ impl<T: Clone + Eq + Debug + Default> WrappedBlock<T> {
                 }
             }
             html_trace_quiet!("  Added char {:?}", c);
+        }
+        Ok(())
+    }
+
+    fn add_text_prewrap(
+        &mut self,
+        text: &str,
+        tag: &T,
+    ) -> Result<(), Error> {
+        html_trace!("WrappedBlock::add_text_prewrap({}), {:?}", text, tag);
+        for c in text.chars() {
+            if c.is_whitespace() {
+                // Wrap if needed
+                self.flush_word(false)?;
+                match c {
+                    '\n' => {
+                        self.force_flush_line();
+                    }
+                    '\t' => {
+                        let tab_stop = 8;
+                        let mut at_least_one_space = false;
+                        while self.linelen % tab_stop != 0 || !at_least_one_space {
+                            if self.linelen >= self.width {
+                                self.flush_line();
+                            } else {
+                                self.line.push_char(
+                                    ' ',
+                                    tag
+                                );
+                                self.linelen += 1;
+                                at_least_one_space = true;
+                            }
+                        }
+                    }
+                    _ => {
+                        if let Some(width) = UnicodeWidthChar::width(c) {
+                            if self.width - self.linelen < width {
+                                self.flush_line();
+                            }
+                            if self.width - self.linelen >= width {
+                                // Check for space again to avoid pathological issues
+                                self.line.push_char(c, tag);
+                                self.linelen += width;
+                            }
+                        }
+                    }
+                }
+            } else if let Some(charwidth) = UnicodeWidthChar::width(c) {
+                /* Not whitespace; add to the current word. */
+                self.word.push_char(c, tag);
+                self.wordlen += charwidth;
+            }
+            html_trace_quiet!("  Added char {:?}, wordlen={}", c, self.wordlen);
         }
         Ok(())
     }
@@ -900,7 +954,7 @@ pub(crate) struct SubRenderer<D: TextDecorator> {
     ann_stack: Vec<D::Annotation>,
     text_filter_stack: Vec<fn(&str) -> Option<String>>,
     /// The depth of `<pre>` block stacking.
-    pre_depth: usize,
+    ws_stack: Vec<WhiteSpace>,
 }
 
 impl<D: TextDecorator> std::fmt::Debug for SubRenderer<D> {
@@ -910,7 +964,7 @@ impl<D: TextDecorator> std::fmt::Debug for SubRenderer<D> {
             .field("lines", &self.lines)
             //.field("decorator", &self.decorator)
             .field("ann_stack", &self.ann_stack)
-            .field("pre_depth", &self.pre_depth)
+            .field("ws_stack", &self.ws_stack)
             .field("wrapping", &self.wrapping)
             .finish()
     }
@@ -993,7 +1047,7 @@ impl<D: TextDecorator> SubRenderer<D> {
             wrapping: None,
             decorator,
             ann_stack: Vec::new(),
-            pre_depth: 0,
+            ws_stack: Vec::new(),
             text_filter_stack: Vec::new(),
         }
     }
@@ -1104,6 +1158,10 @@ impl<D: TextDecorator> SubRenderer<D> {
         }
         Ok(new_width.max(min_width))
     }
+
+    fn ws_mode(&self) -> WhiteSpace {
+        self.ws_stack.last().cloned().unwrap_or(WhiteSpace::Normal)
+    }
 }
 
 fn filter_text_strikeout(s: &str) -> Option<String> {
@@ -1186,16 +1244,12 @@ impl<D: TextDecorator> Renderer for SubRenderer<D> {
         Ok(())
     }
 
-    fn start_pre(&mut self) {
-        self.pre_depth += 1;
+    fn push_ws(&mut self, ws: WhiteSpace) {
+        self.ws_stack.push(ws);
     }
 
-    fn end_pre(&mut self) {
-        if self.pre_depth > 0 {
-            self.pre_depth -= 1;
-        } else {
-            panic!("Attempt to end a preformatted block which wasn't opened.");
-        }
+    fn pop_ws(&mut self) {
+        self.ws_stack.pop();
     }
 
     fn end_block(&mut self) {
@@ -1204,7 +1258,7 @@ impl<D: TextDecorator> Renderer for SubRenderer<D> {
 
     fn add_inline_text(&mut self, text: &str) -> crate::Result<()> {
         html_trace!("add_inline_text({}, {})", self.width, text);
-        if self.pre_depth == 0 && self.at_block_end && text.chars().all(char::is_whitespace) {
+        if !self.ws_mode().preserve_whitespace() && self.at_block_end && text.chars().all(char::is_whitespace) {
             // Ignore whitespace between blocks.
             return Ok(());
         }
@@ -1220,16 +1274,23 @@ impl<D: TextDecorator> Renderer for SubRenderer<D> {
             }
         }
         let filtered_text = s.as_deref().unwrap_or(text);
-        if self.pre_depth == 0 {
-            get_wrapping_or_insert::<D>(&mut self.wrapping, &self.options, self.width)
-                .add_text(filtered_text, &self.ann_stack)?;
-        } else {
-            let mut tag_first = self.ann_stack.clone();
-            let mut tag_cont = self.ann_stack.clone();
-            tag_first.push(self.decorator.decorate_preformat_first());
-            tag_cont.push(self.decorator.decorate_preformat_cont());
-            get_wrapping_or_insert::<D>(&mut self.wrapping, &self.options, self.width)
-                .add_preformatted_text(filtered_text, &tag_first, &tag_cont)?;
+        let ws_mode = self.ws_mode();
+        let wrapping = get_wrapping_or_insert::<D>(&mut self.wrapping, &self.options, self.width);
+        match ws_mode {
+            WhiteSpace::Normal => {
+                wrapping.add_text(filtered_text, &self.ann_stack)?;
+            }
+            WhiteSpace::Pre => {
+                let mut tag_first = self.ann_stack.clone();
+                let mut tag_cont = self.ann_stack.clone();
+                tag_first.push(self.decorator.decorate_preformat_first());
+                tag_cont.push(self.decorator.decorate_preformat_cont());
+                get_wrapping_or_insert::<D>(&mut self.wrapping, &self.options, self.width)
+                    .add_preformatted_text(filtered_text, &tag_first, &tag_cont)?;
+            }
+            WhiteSpace::PreWrap => {
+                wrapping.add_text_prewrap(filtered_text, &self.ann_stack)?;
+            }
         }
         Ok(())
     }

--- a/src/render/text_renderer.rs
+++ b/src/render/text_renderer.rs
@@ -570,11 +570,7 @@ impl<T: Clone + Eq + Debug + Default> WrappedBlock<T> {
         Ok(())
     }
 
-    fn add_text_prewrap(
-        &mut self,
-        text: &str,
-        tag: &T,
-    ) -> Result<(), Error> {
+    fn add_text_prewrap(&mut self, text: &str, tag: &T) -> Result<(), Error> {
         html_trace!("WrappedBlock::add_text_prewrap({}), {:?}", text, tag);
         for c in text.chars() {
             if c.is_whitespace() {
@@ -591,10 +587,7 @@ impl<T: Clone + Eq + Debug + Default> WrappedBlock<T> {
                             if self.linelen >= self.width {
                                 self.flush_line();
                             } else {
-                                self.line.push_char(
-                                    ' ',
-                                    tag
-                                );
+                                self.line.push_char(' ', tag);
                                 self.linelen += 1;
                                 at_least_one_space = true;
                             }
@@ -1258,7 +1251,10 @@ impl<D: TextDecorator> Renderer for SubRenderer<D> {
 
     fn add_inline_text(&mut self, text: &str) -> crate::Result<()> {
         html_trace!("add_inline_text({}, {})", self.width, text);
-        if !self.ws_mode().preserve_whitespace() && self.at_block_end && text.chars().all(char::is_whitespace) {
+        if !self.ws_mode().preserve_whitespace()
+            && self.at_block_end
+            && text.chars().all(char::is_whitespace)
+        {
             // Ignore whitespace between blocks.
             return Ok(());
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2074,7 +2074,9 @@ foo
 
 #[cfg(feature = "css")]
 mod css_tests {
-    use super::{test_html_coloured, test_html_coloured_conf, test_html_conf, test_html_css, test_html_style};
+    use super::{
+        test_html_coloured, test_html_coloured_conf, test_html_conf, test_html_css, test_html_style,
+    };
 
     #[test]
     fn test_disp_none() {
@@ -2570,8 +2572,9 @@ c  d  e
 "#,
             10,
             |conf| {
-                conf.add_css(r#".prewrap { white-space: pre-wrap; }"#).unwrap()
-            }
+                conf.add_css(r#".prewrap { white-space: pre-wrap; }"#)
+                    .unwrap()
+            },
         );
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2074,7 +2074,7 @@ foo
 
 #[cfg(feature = "css")]
 mod css_tests {
-    use super::{test_html_coloured, test_html_coloured_conf, test_html_css, test_html_style};
+    use super::{test_html_coloured, test_html_coloured_conf, test_html_conf, test_html_css, test_html_style};
 
     #[test]
     fn test_disp_none() {
@@ -2549,6 +2549,29 @@ Row│Three
                 )
                 .unwrap()
             },
+        );
+    }
+
+    #[test]
+    fn test_pre_wrap() {
+        test_html_conf(
+            br#"<p class="prewrap">Hi
+ a
+  b
+   x  longword
+c  d  e
+</p>"#,
+            r#"Hi
+ a
+  b
+   x  
+longword
+c  d  e
+"#,
+            10,
+            |conf| {
+                conf.add_css(r#".prewrap { white-space: pre-wrap; }"#).unwrap()
+            }
         );
     }
 }


### PR DESCRIPTION
Add support for CSS `white-space` values `normal`, `pre`, and `pre-wrap`.
Change the implementation of `<pre>` - it's now treated the same as `<p>` with `white-space: pre` (even with CSS disabled - the style is constructed directly rather than going through a CSS parser).

Closes #157 