### PR TITLE
Error wrapping

### DIFF
--- a/src/css.rs
+++ b/src/css.rs
@@ -421,9 +421,9 @@ impl StyleData {
     }
 }
 
-fn pending<'a, F>(handle: Handle, f: F) -> TreeMapResult<'a, (), Handle, Vec<String>>
+fn pending<F>(handle: Handle, f: F) -> TreeMapResult<'static, (), Handle, Vec<String>>
 where
-    for<'r> F: Fn(&'r mut (), Vec<Vec<String>>) -> Result<Option<Vec<String>>> + 'static,
+    F: Fn(&mut (), Vec<Vec<String>>) -> Result<Option<Vec<String>>> + 'static,
 {
     TreeMapResult::PendingChildren {
         children: handle.children.borrow().clone(),
@@ -447,10 +447,10 @@ fn combine_vecs(vecs: Vec<Vec<String>>) -> Vec<String> {
     }
 }
 
-fn extract_style_nodes<'a, T: Write>(
+fn extract_style_nodes<T: Write>(
     handle: Handle,
     _err_out: &mut T,
-) -> TreeMapResult<'a, (), Handle, Vec<String>> {
+) -> TreeMapResult<'static, (), Handle, Vec<String>> {
     use TreeMapResult::*;
 
     match handle.clone().data {

--- a/src/css.rs
+++ b/src/css.rs
@@ -69,12 +69,8 @@ impl Selector {
                     false
                 }
                 SelectorComponent::Element(name) => match &node.data {
-                    Element { name: eltname, .. } => {
-                        if name == eltname.expanded().local.deref() {
-                            Self::do_matches(&comps[1..], node)
-                        } else {
-                            false
-                        }
+                    Element { name: eltname, .. } if name == eltname.expanded().local.deref() => {
+                        Self::do_matches(&comps[1..], node)
                     }
                     _ => false,
                 },

--- a/src/css.rs
+++ b/src/css.rs
@@ -306,11 +306,11 @@ impl StyleData {
 
     pub(crate) fn computed_style(
         &self,
-        parent_style: &ComputedStyle,
+        parent_style: ComputedStyle,
         handle: &Handle,
         use_doc_css: bool,
     ) -> ComputedStyle {
-        let mut result = *parent_style;
+        let mut result = parent_style;
 
         for (origin, ruleset) in [
             (StyleOrigin::Agent, &self.agent_rules),
@@ -467,7 +467,7 @@ fn extract_style_nodes<'a, T: Write>(
                     // Assume just a flat text node
                     for child in handle.children.borrow().iter() {
                         if let NodeData::Text { ref contents } = child.data {
-                            result += &String::from(contents.borrow().deref());
+                            result += &contents.borrow();
                         }
                     }
                     Finished(vec![result])

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1130,10 +1130,8 @@ where
             };
         }
             // No more children, so finally construct the parent.
-            let reduced = (last.construct)(context, last.children)?;
-            let parent = pending_stack.pop();
-            if let Some(node) = reduced {
-                if let Some(mut parent) = parent {
+            if let Some(node) = (last.construct)(context, last.children)? {
+                if let Some(mut parent) = pending_stack.pop() {
                     parent.postfn.as_ref().map(|ref f| f(context, &node));
                     parent.children.push(node);
                     last = parent;
@@ -1143,7 +1141,7 @@ where
                 }
             } else {
                 /* Finished the stack, and have nothing */
-                match parent {
+                match pending_stack.pop() {
                     Some(parent) => last = parent,
                     None => break Ok(None),
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1129,17 +1129,17 @@ where
                 TreeMapResult::Nothing => {}
             };
         }
-                // No more children, so finally construct the parent.
-                if let Some(mut parent) = pending_stack.pop() {
-                    if let Some(node) = (last.construct)(context, last.children)? {
-                        parent.postfn.as_ref().map(|ref f| f(context, &node));
-                        parent.children.push(node);
-                    }
-                    last = parent;
-                    continue;
-                }
-                // Finished the whole stack!
-                break Ok((last.construct)(context, last.children)?);
+        // No more children, so finally construct the parent.
+        if let Some(mut parent) = pending_stack.pop() {
+            if let Some(node) = (last.construct)(context, last.children)? {
+                parent.postfn.as_ref().map(|ref f| f(context, &node));
+                parent.children.push(node);
+            }
+            last = parent;
+            continue;
+        }
+        // Finished the whole stack!
+        break Ok((last.construct)(context, last.children)?);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1129,23 +1129,21 @@ where
                 TreeMapResult::Nothing => {}
             };
         }
-            // No more children, so finally construct the parent.
-            if let Some(node) = (last.construct)(context, last.children)? {
+                // No more children, so finally construct the parent.
                 if let Some(mut parent) = pending_stack.pop() {
-                    parent.postfn.as_ref().map(|ref f| f(context, &node));
-                    parent.children.push(node);
+                    if let Some(node) = (last.construct)(context, last.children)? {
+                        parent.postfn.as_ref().map(|ref f| f(context, &node));
+                        parent.children.push(node);
+                    }
                     last = parent;
                 } else {
                     // Finished the whole stack!
-                    break Ok(Some(node));
+                    if let Some(node) = (last.construct)(context, last.children)? {
+                        break Ok(Some(node));
+                    } else {
+                        break Ok(None);
+                    }
                 }
-            } else {
-                /* Finished the stack, and have nothing */
-                match pending_stack.pop() {
-                    Some(parent) => last = parent,
-                    None => break Ok(None),
-                }
-            }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,15 +358,16 @@ struct RenderTableCell {
 impl RenderTableCell {
     /// Calculate or return the estimate size of the cell
     fn get_size_estimate(&self) -> SizeEstimate {
-        if self.size_estimate.get().is_none() {
+        let Some(size) = self.size_estimate.get() else {
             let size = self
                 .content
                 .iter()
                 .map(|node| node.get_size_estimate())
                 .fold(Default::default(), SizeEstimate::add);
             self.size_estimate.set(Some(size));
-        }
-        self.size_estimate.get().unwrap()
+            return size;
+        };
+        size
     }
 }
 
@@ -1916,10 +1917,10 @@ fn do_render_node<T: Write, D: TextDecorator>(
             // Special case for digit-only superscripts - use superscript
             // characters.
             fn sup_digits(children: &[RenderNode]) -> Option<String> {
-                if children.len() != 1 {
+                let [node] = children else {
                     return None;
-                }
-                if let Text(s) = &children[0].info {
+                };
+                if let Text(s) = &node.info {
                     if s.chars().all(|d| d.is_ascii_digit()) {
                         // It's just a string of digits - replace by superscript characters.
                         const SUPERSCRIPTS: [char; 10] =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1355,7 +1355,7 @@ fn process_dom_node<'a, T: Write>(
                 let computed =
                     context
                         .style_data
-                        .computed_style(parent_style, handle, context.use_doc_css);
+                        .computed_style(**parent_style, handle, context.use_doc_css);
                 if let Some(true) = computed.display_none.val() {
                     return Ok(Nothing);
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1136,13 +1136,13 @@ where
                         parent.children.push(node);
                     }
                     last = parent;
+                    continue;
+                }
+                // Finished the whole stack!
+                if let Some(node) = (last.construct)(context, last.children)? {
+                    break Ok(Some(node));
                 } else {
-                    // Finished the whole stack!
-                    if let Some(node) = (last.construct)(context, last.children)? {
-                        break Ok(Some(node));
-                    } else {
-                        break Ok(None);
-                    }
+                    break Ok(None);
                 }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1632,35 +1632,25 @@ impl PushedStyleInfo {
     fn apply<D: TextDecorator>(render: &mut TextRenderer<D>, style: &ComputedStyle) -> Self {
         #[allow(unused_mut)]
         let mut result: PushedStyleInfo = Default::default();
-        {
-            #[cfg(feature = "css")]
-            if let Some(col) = style.colour.val() {
-                render.push_colour(col);
-                result.colour = true;
-            }
-            #[cfg(feature = "css")]
-            if let Some(col) = style.bg_colour.val() {
-                render.push_bgcolour(col);
-                result.bgcolour = true;
-            }
-            if let Some(ws) = style.white_space.val() {
-                match ws {
-                    WhiteSpace::Normal => {}
-                    WhiteSpace::Pre | WhiteSpace::PreWrap => {
-                        render.push_ws(ws);
-                        result.white_space = true;
-                    }
-                }
-            }
-            if style.internal_pre {
-                render.push_preformat();
-                result.preformat = true;
+        #[cfg(feature = "css")]
+        if let Some(col) = style.colour.val() {
+            render.push_colour(col);
+            result.colour = true;
+        }
+        #[cfg(feature = "css")]
+        if let Some(col) = style.bg_colour.val() {
+            render.push_bgcolour(col);
+            result.bgcolour = true;
+        }
+        if let Some(ws) = style.white_space.val() {
+            if let WhiteSpace::Pre | WhiteSpace::PreWrap = ws {
+                render.push_ws(ws);
+                result.white_space = true;
             }
         }
-        #[cfg(not(feature = "css"))]
-        {
-            let _ = render;
-            let _ = style;
+        if style.internal_pre {
+            render.push_preformat();
+            result.preformat = true;
         }
         result
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1574,6 +1574,7 @@ fn render_tree_to_string<T: Write, D: TextDecorator>(
     err_out: &mut T,
 ) -> Result<SubRenderer<D>> {
     /* Phase 1: get size estimates. */
+    // can't actually error, but Ok-wrap to satisfy tree_map_reduce signature
     tree_map_reduce(context, &tree, |context, node| {
         Ok(precalc_size_estimate(node, context, decorator))
     })?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1101,7 +1101,7 @@ where
     let mut pending_stack = Vec::new();
     loop {
         // Get the next child node to process
-        if let Some(h) = last.to_process.next() {
+        while let Some(h) = last.to_process.next() {
             last.prefn
                 .as_ref()
                 .map(|ref f| f(context, &h))
@@ -1128,7 +1128,7 @@ where
                 }
                 TreeMapResult::Nothing => {}
             };
-        } else {
+        }
             // No more children, so finally construct the parent.
             let reduced = (last.construct)(context, last.children)?;
             let parent = pending_stack.pop();
@@ -1148,7 +1148,6 @@ where
                     None => break Ok(None),
                 }
             }
-        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1139,11 +1139,7 @@ where
                     continue;
                 }
                 // Finished the whole stack!
-                if let Some(node) = (last.construct)(context, last.children)? {
-                    break Ok(Some(node));
-                } else {
-                    break Ok(None);
-                }
+                break Ok((last.construct)(context, last.children)?);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2045,8 +2045,8 @@ fn render_table_tree<T: Write, D: TextDecorator>(
     Ok(TreeMapResult::PendingChildren {
         children: table.into_rows(col_widths, vert_row),
         cons: Box::new(|_, _| Ok(Some(None))),
-        prefn: Some(Box::new(|_, _| Ok(()))),
-        postfn: Some(Box::new(|_, _| Ok(()))),
+        prefn: None,
+        postfn: None,
     })
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,7 @@ impl PartialOrd for Specificity {
 }
 
 #[derive(Clone, Copy, Debug)]
-pub(crate) struct WithSpec<T: Copy + Clone> {
+pub(crate) struct WithSpec<T> {
     val: Option<T>,
     origin: StyleOrigin,
     specificity: Specificity,
@@ -626,7 +626,7 @@ impl RenderNode {
     fn calc_size_estimate<D: TextDecorator>(
         &self,
         context: &HtmlContext,
-        decorator: &'_ D,
+        decorator: &D,
     ) -> SizeEstimate {
         // If it's already calculated, then just return the answer.
         if let Some(s) = self.size_estimate.get() {
@@ -785,12 +785,12 @@ fn precalc_size_estimate<'a, D: TextDecorator>(
     node: &'a RenderNode,
     context: &mut HtmlContext,
     decorator: &'a D,
-) -> Result<TreeMapResult<'a, HtmlContext, &'a RenderNode, ()>> {
+) -> TreeMapResult<'a, HtmlContext, &'a RenderNode, ()> {
     use RenderNodeInfo::*;
     if node.size_estimate.get().is_some() {
-        return Ok(TreeMapResult::Nothing);
+        return TreeMapResult::Nothing;
     }
-    Ok(match node.info {
+    match node.info {
         Text(_) | Img(_, _) | Break | FragStart(_) => {
             let _ = node.calc_size_estimate(context, decorator);
             TreeMapResult::Nothing
@@ -840,7 +840,7 @@ fn precalc_size_estimate<'a, D: TextDecorator>(
             }
         }
         TableRow(..) | TableBody(_) | TableCell(_) => unimplemented!(),
-    })
+    }
 }
 
 /// Make a Vec of RenderNodes from the children of a node.
@@ -1575,7 +1575,7 @@ fn render_tree_to_string<T: Write, D: TextDecorator>(
 ) -> Result<SubRenderer<D>> {
     /* Phase 1: get size estimates. */
     tree_map_reduce(context, &tree, |context, node| {
-        precalc_size_estimate(node, context, decorator)
+        Ok(precalc_size_estimate(node, context, decorator))
     })?;
     /* Phase 2: actually render. */
     let mut renderer = TextRenderer::new(renderer);

--- a/src/markup5ever_rcdom.rs
+++ b/src/markup5ever_rcdom.rs
@@ -168,23 +168,20 @@ fn append(new_parent: &Handle, child: Handle) {
 
 /// If the node has a parent, get it and this node's position in its children
 fn get_parent_and_index(target: &Handle) -> Option<(Handle, usize)> {
-    if let Some(weak) = target.parent.take() {
-        let parent = weak.upgrade().expect("dangling weak pointer");
-        target.parent.set(Some(weak));
-        let i = match parent
-            .children
-            .borrow()
-            .iter()
-            .enumerate()
-            .find(|&(_, child)| Rc::ptr_eq(child, target))
-        {
-            Some((i, _)) => i,
-            None => panic!("have parent but couldn't find in parent's children!"),
-        };
-        Some((parent, i))
-    } else {
-        None
-    }
+    let weak = target.parent.take()?;
+    let parent = weak.upgrade().expect("dangling weak pointer");
+    target.parent.set(Some(weak));
+    let i = match parent
+        .children
+        .borrow()
+        .iter()
+        .enumerate()
+        .find(|&(_, child)| Rc::ptr_eq(child, target))
+    {
+        Some((i, _)) => i,
+        None => panic!("have parent but couldn't find in parent's children!"),
+    };
+    Some((parent, i))
 }
 
 fn append_to_existing_text(prev: &Handle, text: &str) -> bool {

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -2,7 +2,6 @@
 //! particular text output.
 
 use crate::Colour;
-use crate::Error;
 use crate::WhiteSpace;
 
 pub(crate) mod text_renderer;
@@ -12,36 +11,47 @@ pub use text_renderer::{
     TrivialDecorator,
 };
 
+pub(crate) type Result<T> = std::result::Result<T, TooNarrow>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TooNarrow;
+
+impl From<TooNarrow> for crate::Error {
+    fn from(_: TooNarrow) -> crate::Error {
+        crate::Error::TooNarrow
+    }
+}
+
 /// A type which is a backend for HTML to text rendering.
 pub(crate) trait Renderer {
     /// Add an empty line to the output (ie between blocks).
-    fn add_empty_line(&mut self) -> crate::Result<()>;
+    fn add_empty_line(&mut self) -> Result<()>;
 
     /// Create a sub-renderer for nested blocks.
-    fn new_sub_renderer(&self, width: usize) -> crate::Result<Self>
+    fn new_sub_renderer(&self, width: usize) -> Result<Self>
     where
         Self: Sized;
 
     /// Start a new block.
-    fn start_block(&mut self) -> crate::Result<()>;
+    fn start_block(&mut self) -> Result<()>;
 
     /// Mark the end of a block.
     fn end_block(&mut self);
 
     /// Start a new line, if necessary (but don't add a new line).
-    fn new_line(&mut self) -> Result<(), Error>;
+    fn new_line(&mut self) -> Result<()>;
 
     /// Start a new line.
-    fn new_line_hard(&mut self) -> Result<(), Error>;
+    fn new_line_hard(&mut self) -> Result<()>;
 
     /// Add a horizontal table border.
-    fn add_horizontal_border(&mut self) -> Result<(), Error>;
+    fn add_horizontal_border(&mut self) -> Result<()>;
 
     /// Add a horizontal border which is not the full width
     fn add_horizontal_border_width(
         &mut self,
         #[allow(unused_variables)] width: usize,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         self.add_horizontal_border()
     }
 
@@ -58,18 +68,16 @@ pub(crate) trait Renderer {
     /// End the current white-space setting.
     fn pop_ws(&mut self);
 
-    //
-
     /// Add some inline text (which should be wrapped at the
     /// appropriate width) to the current block.
-    fn add_inline_text(&mut self, text: &str) -> crate::Result<()>;
+    fn add_inline_text(&mut self, text: &str) -> Result<()>;
 
     /// Return the current width in character cells
     fn width(&self) -> usize;
 
     /// Add a new block from a sub renderer, and prefix every line by the
     /// corresponding text from each iteration of prefixes.
-    fn append_subrender<'a, I>(&mut self, other: Self, prefixes: I) -> Result<(), Error>
+    fn append_subrender<'a, I>(&mut self, other: Self, prefixes: I) -> Result<()>
     where
         I: Iterator<Item = &'a str>;
 
@@ -77,14 +85,14 @@ pub(crate) trait Renderer {
     /// and add a horizontal line below.
     /// If collapse is true, then merge top/bottom borders of the subrenderer
     /// with the surrounding one.
-    fn append_columns_with_borders<I>(&mut self, cols: I, collapse: bool) -> Result<(), Error>
+    fn append_columns_with_borders<I>(&mut self, cols: I, collapse: bool) -> Result<()>
     where
         I: IntoIterator<Item = Self>,
         Self: Sized;
 
     /// Append a set of sub renderers joined vertically with lines, for tables
     /// which would otherwise be too wide for the screen.
-    fn append_vert_row<I>(&mut self, cols: I) -> Result<(), Error>
+    fn append_vert_row<I>(&mut self, cols: I) -> Result<()>
     where
         I: IntoIterator<Item = Self>,
         Self: Sized;
@@ -95,37 +103,37 @@ pub(crate) trait Renderer {
     /// Start a hyperlink
     /// TODO: return sub-builder or similar to make misuse
     /// of start/link harder?
-    fn start_link(&mut self, target: &str) -> crate::Result<()>;
+    fn start_link(&mut self, target: &str) -> Result<()>;
 
     /// Finish a hyperlink started earlier.
-    fn end_link(&mut self) -> crate::Result<()>;
+    fn end_link(&mut self) -> Result<()>;
 
     /// Start an emphasised region
-    fn start_emphasis(&mut self) -> crate::Result<()>;
+    fn start_emphasis(&mut self) -> Result<()>;
 
     /// Finish emphasised text started earlier.
-    fn end_emphasis(&mut self) -> crate::Result<()>;
+    fn end_emphasis(&mut self) -> Result<()>;
 
     /// Start a strong region
-    fn start_strong(&mut self) -> crate::Result<()>;
+    fn start_strong(&mut self) -> Result<()>;
 
     /// Finish strong text started earlier.
-    fn end_strong(&mut self) -> crate::Result<()>;
+    fn end_strong(&mut self) -> Result<()>;
 
     /// Start a strikeout region
-    fn start_strikeout(&mut self) -> crate::Result<()>;
+    fn start_strikeout(&mut self) -> Result<()>;
 
     /// Finish strikeout text started earlier.
-    fn end_strikeout(&mut self) -> crate::Result<()>;
+    fn end_strikeout(&mut self) -> Result<()>;
 
     /// Start a code region
-    fn start_code(&mut self) -> crate::Result<()>;
+    fn start_code(&mut self) -> Result<()>;
 
     /// End a code region
-    fn end_code(&mut self) -> crate::Result<()>;
+    fn end_code(&mut self) -> Result<()>;
 
     /// Add an image
-    fn add_image(&mut self, src: &str, title: &str) -> crate::Result<()>;
+    fn add_image(&mut self, src: &str, title: &str) -> Result<()>;
 
     /// Get prefix string of header in specific level.
     fn header_prefix(&mut self, level: usize) -> String;
@@ -159,8 +167,8 @@ pub(crate) trait Renderer {
     fn pop_bgcolour(&mut self);
 
     /// Start a section of superscript text.
-    fn start_superscript(&mut self) -> crate::Result<()>;
+    fn start_superscript(&mut self) -> Result<()>;
 
     /// End a section of superscript text.
-    fn end_superscript(&mut self) -> crate::Result<()>;
+    fn end_superscript(&mut self) -> Result<()>;
 }

--- a/src/render/text_renderer.rs
+++ b/src/render/text_renderer.rs
@@ -905,7 +905,8 @@ pub(crate) enum RenderLine<T> {
 
 impl<T: PartialEq + Eq + Clone + Debug + Default> RenderLine<T> {
     /// Turn the rendered line into a String
-    fn into_string(self) -> String {
+    #[allow(clippy::inherent_to_string)]
+    fn to_string(&self) -> String {
         match self {
             RenderLine::Text(tagged) => tagged.to_string(),
             RenderLine::Line(border) => border.to_string(),
@@ -928,15 +929,6 @@ impl<T: PartialEq + Eq + Clone + Debug + Default> RenderLine<T> {
                 }));
                 tagged
             }
-        }
-    }
-
-    #[cfg(feature = "html_trace")]
-    /// For testing, return a simple string of the contents.
-    fn to_string(&self) -> String {
-        match self {
-            RenderLine::Text(tagged) => tagged.to_string(),
-            RenderLine::Line(border) => border.to_string(),
         }
     }
 
@@ -1090,7 +1082,7 @@ impl<D: TextDecorator> SubRenderer<D> {
         #[cfg(feature = "html_trace")]
         let width: usize = self.width;
         for line in self.into_lines()? {
-            result.push_str(&line.into_string());
+            result.push_str(&line.to_string());
             result.push('\n');
         }
         html_trace!("into_string({}, {:?})", width, result);

--- a/src/render/text_renderer.rs
+++ b/src/render/text_renderer.rs
@@ -162,9 +162,10 @@ impl<T: Debug + Eq + PartialEq + Clone + Default> TaggedLine<T> {
     }
 
     /// Join the line into a String, ignoring the tags and markers.
-    fn into_string(self) -> String {
+    #[allow(clippy::inherent_to_string)]
+    fn to_string(&self) -> String {
         let mut s = String::new();
-        for tle in self.v {
+        for tle in &self.v {
             if let TaggedLineElement::Str(ts) = tle {
                 s.push_str(&ts.s);
             }
@@ -260,8 +261,7 @@ impl<T: Debug + Eq + PartialEq + Clone + Default> TaggedLine<T> {
     }
 
     /// Iterator over the chars in this line.
-    #[allow(clippy::needless_lifetimes)]
-    pub fn chars<'a>(&'a self) -> impl Iterator<Item = char> + 'a {
+    pub fn chars(&self) -> impl Iterator<Item = char> + '_ {
         use self::TaggedLineElement::Str;
 
         self.v.iter().flat_map(|tle| {
@@ -271,12 +271,6 @@ impl<T: Debug + Eq + PartialEq + Clone + Default> TaggedLine<T> {
                 "".chars()
             }
         })
-    }
-
-    #[cfg(feature = "html_trace")]
-    /// Return a string contents for debugging.
-    fn to_string(&self) -> String {
-        self.chars().collect()
     }
 
     /// Iterator over TaggedLineElements
@@ -913,7 +907,7 @@ impl<T: PartialEq + Eq + Clone + Debug + Default> RenderLine<T> {
     /// Turn the rendered line into a String
     fn into_string(self) -> String {
         match self {
-            RenderLine::Text(tagged) => tagged.into_string(),
+            RenderLine::Text(tagged) => tagged.to_string(),
             RenderLine::Line(border) => border.to_string(),
         }
     }

--- a/src/render/text_renderer.rs
+++ b/src/render/text_renderer.rs
@@ -1077,20 +1077,20 @@ impl<D: TextDecorator> SubRenderer<D> {
     }
 
     /// Consumes this renderer and return a multiline `String` with the result.
-    pub fn into_string(self) -> Result<String, Error> {
+    pub fn into_string(mut self) -> Result<String, Error> {
         let mut result = String::new();
-        #[cfg(feature = "html_trace")]
-        let width: usize = self.width;
-        for line in self.into_lines()? {
+        self.flush_wrapping()?;
+        for line in &self.lines {
             result.push_str(&line.to_string());
             result.push('\n');
         }
-        html_trace!("into_string({}, {:?})", width, result);
+        html_trace!("into_string({}, {:?})", self.width, result);
         Ok(result)
     }
 
     #[cfg(feature = "html_trace")]
     /// Returns a string of the current builder contents (for testing).
+    #[allow(clippy::inherent_to_string)]
     fn to_string(&self) -> String {
         let mut result = String::new();
         for line in &self.lines {

--- a/src/render/text_renderer.rs
+++ b/src/render/text_renderer.rs
@@ -885,9 +885,10 @@ impl<T: Clone> BorderHoriz<T> {
     }
 
     /// Turn into a string with drawing characters
-    fn into_string(self) -> String {
+    #[allow(clippy::inherent_to_string)]
+    fn to_string(&self) -> String {
         self.segments
-            .into_iter()
+            .iter()
             .map(|seg| match seg {
                 BorderSegHoriz::Straight => '─',
                 BorderSegHoriz::StraightVert => '/',
@@ -896,12 +897,6 @@ impl<T: Clone> BorderHoriz<T> {
                 BorderSegHoriz::JoinCross => '┼',
             })
             .collect::<String>()
-    }
-
-    /// Return a string without destroying self
-    #[allow(clippy::inherent_to_string)]
-    fn to_string(&self) -> String {
-        self.clone().into_string()
     }
 }
 
@@ -919,7 +914,7 @@ impl<T: PartialEq + Eq + Clone + Debug + Default> RenderLine<T> {
     fn into_string(self) -> String {
         match self {
             RenderLine::Text(tagged) => tagged.into_string(),
-            RenderLine::Line(border) => border.into_string(),
+            RenderLine::Line(border) => border.to_string(),
         }
     }
 
@@ -934,7 +929,7 @@ impl<T: PartialEq + Eq + Clone + Debug + Default> RenderLine<T> {
                 let mut tagged = TaggedLine::new();
                 let tag = border.tag.clone();
                 tagged.push(Str(TaggedString {
-                    s: border.into_string(),
+                    s: border.to_string(),
                     tag,
                 }));
                 tagged
@@ -1370,7 +1365,7 @@ impl<D: TextDecorator> Renderer for SubRenderer<D> {
                             tag: tag.clone(),
                         }));
                         tline.push(Str(TaggedString {
-                            s: l.into_string(),
+                            s: l.to_string(),
                             tag: tag.clone(),
                         }));
                         RenderLine::Text(tline)


### PR DESCRIPTION
I was taking a closer look at error handling, I noticed that some small changes can make it simpler to understand where errors are coming from.

The two most significant changes are to introduce a specific rendering error type that is only converted to the library-wide `Error` as late as possible and to move Ok-wrapping of closure return types as close to the `cons` identifier as possible. This last change permits grepping for the `cons` identifier and one can see at a glance whether the closure can error or not.