### PR TITLE
Fix handling of some invalid colours.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Possible log types:
 
 ### Latest
 
+### 0.13.3
+
+- [fixed] Handle some obsolete `bgcolor=...` attributes.
+- [added] html2text example has `--show-render` to help debugging render issues.
+- [changed] Some error handling and other tidyups (thanks sftse)
+
 ### 0.13.2
 
 - [fixed] Fixed errors when building with Rust 1.72.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "html2text"
-version = "0.13.2"
+version = "0.13.3"
 authors = ["Chris Emerson <github@mail.nosreme.org>"]
 description = "Render HTML as plain text."
 repository = "https://github.com/jugglerchris/rust-html2text/"

--- a/examples/html2text.rs
+++ b/examples/html2text.rs
@@ -132,7 +132,11 @@ where
         let dom = conf.parse_html(input).unwrap();
         dom.as_dom_string()
     } else if flags.show_render {
-        todo!()
+        let conf = config::plain();
+        let conf = update_config(conf, &flags);
+        let dom = conf.parse_html(input).unwrap();
+        let rendertree = conf.dom_to_render_tree(&dom).unwrap();
+        rendertree.to_string()
     } else if literal {
         let conf = config::with_decorator(TrivialDecorator::new());
         let conf = update_config(conf, &flags);
@@ -144,6 +148,7 @@ where
     }
 }
 
+#[derive(Debug)]
 struct Flags {
     width: usize,
     wrap_width: Option<usize>,

--- a/src/css/parser.rs
+++ b/src/css/parser.rs
@@ -385,13 +385,15 @@ pub(crate) fn parse_color_attribute(
     text: &str,
 ) -> Result<Colour, nom::Err<nom::error::Error<&'static str>>> {
     let (_rest, value) = parse_value(text).map_err(|_| empty_fail())?;
-    parse_color(&value.tokens)
-        .or_else(|e| parse_faulty_color(e, text))
+    parse_color(&value.tokens).or_else(|e| parse_faulty_color(e, text))
 }
 
 // Both Firefox and Chromium accept "00aabb" as a bgcolor - I'm not sure this has ever been legal,
 // but regrettably I've had e-mails which were unreadable without doing this.
-fn parse_faulty_color(e: nom::Err<nom::error::Error<&'static str>>, text: &str) -> Result<Colour, nom::Err<nom::error::Error<&'static str>>> {
+fn parse_faulty_color(
+    e: nom::Err<nom::error::Error<&'static str>>,
+    text: &str,
+) -> Result<Colour, nom::Err<nom::error::Error<&'static str>>> {
     let text = text.trim();
     if text.chars().all(|c| c.is_hex_digit()) {
         if text.len() == 6 {

--- a/src/css/parser.rs
+++ b/src/css/parser.rs
@@ -386,6 +386,22 @@ pub(crate) fn parse_color_attribute(
 ) -> Result<Colour, nom::Err<nom::error::Error<&'static str>>> {
     let (_rest, value) = parse_value(text).map_err(|_| empty_fail())?;
     parse_color(&value.tokens)
+        .or_else(|e| parse_faulty_color(e, text))
+}
+
+// Both Firefox and Chromium accept "00aabb" as a bgcolor - I'm not sure this has ever been legal,
+// but regrettably I've had e-mails which were unreadable without doing this.
+fn parse_faulty_color(e: nom::Err<nom::error::Error<&'static str>>, text: &str) -> Result<Colour, nom::Err<nom::error::Error<&'static str>>> {
+    let text = text.trim();
+    if text.chars().all(|c| c.is_hex_digit()) {
+        if text.len() == 6 {
+            let r = u8::from_str_radix(&text[0..2], 16).unwrap();
+            let g = u8::from_str_radix(&text[2..4], 16).unwrap();
+            let b = u8::from_str_radix(&text[4..6], 16).unwrap();
+            return Ok(Colour::Rgb(r, g, b));
+        }
+    }
+    Err(e)
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -780,20 +780,40 @@ impl RenderNode {
         }
     }
 
-    fn write_container(&self, name: &str, items: &[RenderNode], f: &mut std::fmt::Formatter, indent: usize) -> std::prelude::v1::Result<(), std::fmt::Error> {
+    fn write_container(
+        &self,
+        name: &str,
+        items: &[RenderNode],
+        f: &mut std::fmt::Formatter,
+        indent: usize,
+    ) -> std::prelude::v1::Result<(), std::fmt::Error> {
         writeln!(f, "{:indent$}{name}:", "")?;
         for item in items {
-            item.write_self(f, indent+1)?;
+            item.write_self(f, indent + 1)?;
         }
         Ok(())
     }
-    fn write_style(f: &mut std::fmt::Formatter, indent: usize, style: &ComputedStyle) -> std::result::Result<(), std::fmt::Error> {
-        writeln!(f, "{:indent$}[Style: colour={:?} bgcolour={:?} disp={:?} ws={:?} in_pre={}]", "",
-            style.colour.val(), style.bg_colour.val(),
-            style.display_none.val(), style.white_space.val(),
-            style.internal_pre)
+    fn write_style(
+        f: &mut std::fmt::Formatter,
+        indent: usize,
+        style: &ComputedStyle,
+    ) -> std::result::Result<(), std::fmt::Error> {
+        writeln!(
+            f,
+            "{:indent$}[Style: colour={:?} bgcolour={:?} disp={:?} ws={:?} in_pre={}]",
+            "",
+            style.colour.val(),
+            style.bg_colour.val(),
+            style.display_none.val(),
+            style.white_space.val(),
+            style.internal_pre
+        )
     }
-    fn write_self(&self, f: &mut std::fmt::Formatter, indent: usize) -> std::prelude::v1::Result<(), std::fmt::Error> {
+    fn write_self(
+        &self,
+        f: &mut std::fmt::Formatter,
+        indent: usize,
+    ) -> std::prelude::v1::Result<(), std::fmt::Error> {
         Self::write_style(f, indent, &self.style)?;
 
         match &self.info {
@@ -804,39 +824,74 @@ impl RenderNode {
             RenderNodeInfo::Link(targ, v) => {
                 self.write_container(&format!("Link({})", targ), &v, f, indent)?;
             }
-            RenderNodeInfo::Em(_) => todo!(),
+            RenderNodeInfo::Em(v) => {
+                self.write_container("Em", &v, f, indent)?;
+            }
             RenderNodeInfo::Strong(v) => {
                 self.write_container("Strong", &v, f, indent)?;
             }
-            RenderNodeInfo::Strikeout(_) => todo!(),
-            RenderNodeInfo::Code(_) => todo!(),
+            RenderNodeInfo::Strikeout(v) => {
+                self.write_container("Strikeout", &v, f, indent)?;
+            }
+            RenderNodeInfo::Code(v) => {
+                self.write_container("Code", &v, f, indent)?;
+            }
             RenderNodeInfo::Img(src, title) => {
                 writeln!(f, "{:indent$}Img src={:?} title={:?}:", "", src, title)?;
             }
-            RenderNodeInfo::Block(_) => todo!(),
-            RenderNodeInfo::Header(_, _) => todo!(),
+            RenderNodeInfo::Block(v) => {
+                self.write_container("Block", &v, f, indent)?;
+            }
+            RenderNodeInfo::Header(depth, v) => {
+                self.write_container(&format!("Header({})", depth), &v, f, indent)?;
+            }
             RenderNodeInfo::Div(v) => {
                 self.write_container("Div", &v, f, indent)?;
             }
-            RenderNodeInfo::BlockQuote(_) => todo!(),
-            RenderNodeInfo::Ul(_) => todo!(),
-            RenderNodeInfo::Ol(_, _) => todo!(),
-            RenderNodeInfo::Dl(_) => todo!(),
-            RenderNodeInfo::Dt(_) => todo!(),
-            RenderNodeInfo::Dd(_) => todo!(),
+            RenderNodeInfo::BlockQuote(v) => {
+                self.write_container("BlockQuote", &v, f, indent)?;
+            }
+            RenderNodeInfo::Ul(v) => {
+                self.write_container("Ul", &v, f, indent)?;
+            }
+            RenderNodeInfo::Ol(start, v) => {
+                self.write_container(&format!("Ol({})", start), &v, f, indent)?;
+            }
+            RenderNodeInfo::Dl(v) => {
+                self.write_container("Dl", &v, f, indent)?;
+            }
+            RenderNodeInfo::Dt(v) => {
+                self.write_container("Dt", &v, f, indent)?;
+            }
+            RenderNodeInfo::Dd(v) => {
+                self.write_container("Dd", &v, f, indent)?;
+            }
             RenderNodeInfo::Break => {
-                writeln!(f, "{:indent$}Break", "", indent=indent)?;
+                writeln!(f, "{:indent$}Break", "", indent = indent)?;
             }
             RenderNodeInfo::Table(rows) => {
                 writeln!(f, "{:indent$}Table ({} cols):", "", rows.num_columns)?;
                 for rtr in &rows.rows {
-                    Self::write_style(f, indent+1, &rtr.style)?;
-                    writeln!(f, "{:width$}Row ({} cells):", "", rtr.cells.len(), width=indent+1)?;
+                    Self::write_style(f, indent + 1, &rtr.style)?;
+                    writeln!(
+                        f,
+                        "{:width$}Row ({} cells):",
+                        "",
+                        rtr.cells.len(),
+                        width = indent + 1
+                    )?;
                     for cell in &rtr.cells {
-                        Self::write_style(f, indent+2, &cell.style)?;
-                        writeln!(f, "{:width$}Cell colspan={} width={:?}:", "", cell.colspan, cell.col_width, width=indent+2)?;
+                        Self::write_style(f, indent + 2, &cell.style)?;
+                        writeln!(
+                            f,
+                            "{:width$}Cell colspan={} width={:?}:",
+                            "",
+                            cell.colspan,
+                            cell.col_width,
+                            width = indent + 2
+                        )?;
                         for node in &cell.content {
-                            node.write_self(f, indent+3)?;
+                            node.write_self(f, indent + 3)?;
                         }
                     }
                 }
@@ -847,8 +902,12 @@ impl RenderNode {
             RenderNodeInfo::FragStart(frag) => {
                 writeln!(f, "{:indent$}FragStart({}):", "", frag)?;
             }
-            RenderNodeInfo::ListItem(_) => todo!(),
-            RenderNodeInfo::Sup(_) => todo!(),
+            RenderNodeInfo::ListItem(v) => {
+                self.write_container("ListItem", &v, f, indent)?;
+            }
+            RenderNodeInfo::Sup(v) => {
+                self.write_container("Sup", &v, f, indent)?;
+            }
         }
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -798,16 +798,27 @@ impl RenderNode {
         indent: usize,
         style: &ComputedStyle,
     ) -> std::result::Result<(), std::fmt::Error> {
-        writeln!(
-            f,
-            "{:indent$}[Style: colour={:?} bgcolour={:?} disp={:?} ws={:?} in_pre={}]",
-            "",
-            style.colour.val(),
-            style.bg_colour.val(),
-            style.display_none.val(),
-            style.white_space.val(),
-            style.internal_pre
-        )
+        write!(f, "{:indent$}[Style:", "")?;
+
+        #[cfg(feature = "css")]
+        {
+            if let Some(col) = style.colour.val() {
+                write!(f, " colour={:?}", col)?;
+            }
+            if let Some(col) = style.bg_colour.val() {
+                write!(f, " bg_colour={:?}", col)?;
+            }
+            if let Some(val) = style.display_none.val() {
+                write!(f, " disp_none={:?}", val)?;
+            }
+        }
+        if let Some(ws) = style.white_space.val() {
+            write!(f, " white_space={:?}", ws)?;
+        }
+        if style.internal_pre {
+            write!(f, " internal_pre")?;
+        }
+        writeln!(f, "")
     }
     fn write_self(
         &self,


### PR DESCRIPTION
Some e-mails seem to use `<table bgcolor="123456">` - note no `#`, not to mention that `bgcolor` is heavily discouraged in favour of CSS.  However, Firefox and Chromium both interpret this as equivalent to `background-color: #123456`, and the e-mail was partly unreadable without (white-on-white).

Also add `html2text --show-render` to help debugging the render tree.