### PR TITLE
Add `:nth-child()` and (as a debug extension) `display: x-raw-dom`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ html_trace = ["dep:log"]
 html_trace_bt = ["html_trace", "dep:backtrace"]
 default = []
 css = []
+css_ext = ["css"]
 
 [[example]]
 name = "html2term"

--- a/examples/html2term.rs
+++ b/examples/html2term.rs
@@ -26,36 +26,21 @@ mod top {
                     style.push_str(&format!("{}", termion::style::Underline));
                 }
                 RichAnnotation::Image(_) => {
-                    style.push_str(&format!(
-                        "{}",
-                        Fg(LightBlue)
-                    ));
+                    style.push_str(&format!("{}", Fg(LightBlue)));
                 }
                 RichAnnotation::Emphasis => {
-                    style.push_str(&format!(
-                        "{}",
-                        Fg(LightGreen)
-                    ));
+                    style.push_str(&format!("{}", Fg(LightGreen)));
                 }
                 RichAnnotation::Strong => {
-                    style.push_str(&format!(
-                        "{}",
-                        Fg(LightGreen)
-                    ));
+                    style.push_str(&format!("{}", Fg(LightGreen)));
                 }
                 RichAnnotation::Strikeout => (),
                 RichAnnotation::Code => {
-                    style.push_str(&format!(
-                        "{}",
-                        Fg(LightYellow)
-                    ));
+                    style.push_str(&format!("{}", Fg(LightYellow)));
                 }
                 RichAnnotation::Preformat(is_cont) => {
                     if is_cont {
-                        style.push_str(&format!(
-                            "{}",
-                            Fg(LightMagenta)
-                        ));
+                        style.push_str(&format!("{}", Fg(LightMagenta)));
                     } else {
                         style.push_str(&format!("{}", Fg(Magenta)));
                     }
@@ -170,7 +155,9 @@ mod top {
 
         let mut file = std::fs::File::open(filename).expect("Tried to open file");
 
-        let dom = html2text::config::plain().parse_html(&mut file).expect("Failed to parse HTML");
+        let dom = html2text::config::plain()
+            .parse_html(&mut file)
+            .expect("Failed to parse HTML");
 
         let mut keys = io::stdin().keys();
 
@@ -242,7 +229,14 @@ mod top {
                     node = node.nth_child(idx).unwrap();
                     pth.push_str(&format!("> {}", node.element_name().unwrap()));
                 }
-                write!(screen, "{}{}{:?}", Goto(1, vis_y_limit as u16), pth, &inspect_path).unwrap();
+                write!(
+                    screen,
+                    "{}{}{:?}",
+                    Goto(1, vis_y_limit as u16),
+                    pth,
+                    &inspect_path
+                )
+                .unwrap();
             }
 
             // 1-based screen coordinates
@@ -356,37 +350,60 @@ mod top {
         }
     }
 
-    fn rerender(dom: &html2text::RcDom, inspect_path: &[usize], width: usize, options: &Options) -> Vec<TaggedLine<Vec<RichAnnotation>>> {
+    fn rerender(
+        dom: &html2text::RcDom,
+        inspect_path: &[usize],
+        width: usize,
+        options: &Options,
+    ) -> Vec<TaggedLine<Vec<RichAnnotation>>> {
         let config = html2text::config::rich();
         #[cfg(feature = "css")]
         let config = if options.use_css {
-            config.use_doc_css()
-                .add_agent_css(r#"
+            config
+                .use_doc_css()
+                .add_agent_css(
+                    r#"
                     img {
                         color: #77f;
                     }
-                "#).unwrap()
+                "#,
+                )
+                .unwrap()
         } else {
             config
         };
         if inspect_path.is_empty() {
-            let render_tree = config.dom_to_render_tree(&dom).expect("Failed to build render tree");
-            config.render_to_lines(render_tree, width).expect("Failed to render")
+            let render_tree = config
+                .dom_to_render_tree(&dom)
+                .expect("Failed to build render tree");
+            config
+                .render_to_lines(render_tree, width)
+                .expect("Failed to render")
         } else {
             let mut path_selector = String::new();
             for &idx in &inspect_path[1..] {
                 path_selector.push_str(&format!(" > :nth-child({})", idx));
             }
             let config = config
-                .add_agent_css(&(format!(r#"
+                .add_agent_css(
+                    &(format!(
+                        r#"
                     html {} {{
                         color: white !important;
                         background-color: black !important;
                         display: x-raw-dom;
                     }}
-                "#, path_selector))).expect("Invalid CSS");
-            let render_tree = config.dom_to_render_tree(&dom).expect("Failed to build render tree");
-            config.render_to_lines(render_tree, width).expect("Failed to render")
+                "#,
+                        path_selector
+                    )),
+                )
+                .expect("Invalid CSS");
+            let render_tree = config
+                .dom_to_render_tree(&dom)
+                .expect("Failed to build render tree");
+            config
+                .render_to_lines(render_tree, width)
+                .expect("Failed to render")
         }
     }
 }

--- a/examples/html2term.rs
+++ b/examples/html2term.rs
@@ -238,13 +238,9 @@ mod top {
                 let mut pth = String::from("top ");
                 let mut node = dom.document.clone();
 
-                let mut l=1;
                 for &idx in &inspect_path {
                     node = node.nth_child(idx).unwrap();
                     pth.push_str(&format!("> {}", node.element_name().unwrap()));
-
-                    pth.push_str(&format!("[{}]", dom.get_node_by_path(&inspect_path[..l]).unwrap().element_name().unwrap()));
-                    l += 1;
                 }
                 write!(screen, "{}{}{:?}", Goto(1, vis_y_limit as u16), pth, &inspect_path).unwrap();
             }

--- a/examples/html2term.rs
+++ b/examples/html2term.rs
@@ -4,9 +4,9 @@ extern crate argparse;
 extern crate unicode_width;
 #[cfg(unix)]
 mod top {
-    use argparse::{ArgumentParser, Store};
     #[cfg(feature = "css")]
     use argparse::StoreFalse;
+    use argparse::{ArgumentParser, Store};
     use html2text::render::{RichAnnotation, TaggedLine, TaggedLineElement};
     use std::collections::HashMap;
     use std::io::{self, Write};
@@ -358,8 +358,7 @@ mod top {
         dom: &html2text::RcDom,
         inspect_path: &[usize],
         width: usize,
-        #[allow(unused)]
-        options: &Options,
+        #[allow(unused)] options: &Options,
     ) -> Vec<TaggedLine<Vec<RichAnnotation>>> {
         let config = html2text::config::rich();
         #[cfg(feature = "css")]
@@ -394,14 +393,14 @@ mod top {
                 let config = config
                     .add_agent_css(
                         &(format!(
-                                r#"
+                            r#"
                     html {} {{
                         color: white !important;
                         background-color: black !important;
                         display: x-raw-dom;
                     }}
                 "#,
-                path_selector
+                            path_selector
                         )),
                     )
                     .expect("Invalid CSS");

--- a/examples/html2text.rs
+++ b/examples/html2text.rs
@@ -253,6 +253,7 @@ fn main() {
             StoreTrue,
             "Show the computed render tree instead of the rendered output",
         );
+        #[cfg(feature = "css")]
         ap.refer(&mut flags.show_css).add_option(
             &["--show-css"],
             StoreTrue,

--- a/examples/html2text.rs
+++ b/examples/html2text.rs
@@ -126,6 +126,15 @@ where
                 .unwrap();
         }
     }
+    #[cfg(feature = "css")]
+    {
+        if flags.show_css {
+            let conf = config::plain();
+            let conf = update_config(conf, &flags);
+            let dom = conf.parse_html(input).unwrap();
+            return html2text::dom_to_parsed_style(&dom).expect("Parsing CSS");
+        }
+    }
     if flags.show_dom {
         let conf = config::plain();
         let conf = update_config(conf, &flags);
@@ -162,6 +171,8 @@ struct Flags {
     use_only_css: bool,
     show_dom: bool,
     show_render: bool,
+    #[cfg(feature = "css")]
+    show_css: bool,
 }
 
 fn main() {
@@ -182,6 +193,8 @@ fn main() {
         use_only_css: false,
         show_dom: false,
         show_render: false,
+        #[cfg(feature = "css")]
+        show_css: false,
     };
     let mut literal: bool = false;
 
@@ -239,6 +252,11 @@ fn main() {
             &["--show-render"],
             StoreTrue,
             "Show the computed render tree instead of the rendered output",
+        );
+        ap.refer(&mut flags.show_css).add_option(
+            &["--show-css"],
+            StoreTrue,
+            "Show the parsed CSS instead of rendered output",
         );
         ap.parse_args_or_exit();
     }

--- a/src/css.rs
+++ b/src/css.rs
@@ -1,13 +1,14 @@
 //! Some basic CSS support.
-use std::{io::Write, rc::Rc};
 use std::ops::Deref;
+use std::{io::Write, rc::Rc};
 
 mod parser;
 
 use crate::{
     css::parser::parse_rules,
     markup5ever_rcdom::{
-        Handle, NodeData::{self, Comment, Document, Element}
+        Handle,
+        NodeData::{self, Comment, Document, Element},
     },
     tree_map_reduce, Colour, ComputedStyle, Result, Specificity, StyleOrigin, TreeMapResult,
     WhiteSpace,
@@ -225,9 +226,7 @@ impl std::fmt::Display for StyleDecl {
         }
         match self.importance {
             Importance::Default => (),
-            Importance::Important => {
-                write!(f, " !important")?
-            }
+            Importance::Important => write!(f, " !important")?,
         }
         Ok(())
     }
@@ -325,24 +324,22 @@ fn styles_from_properties(decls: &[parser::Declaration]) -> Vec<StyleDecl> {
                 overflow_hidden = true;
             }
             parser::Decl::Overflow { .. } | parser::Decl::OverflowY { .. } => {}
-            parser::Decl::Display { value } => {
-                match value {
-                    parser::Display::None => {
-                        styles.push(StyleDecl {
-                            style: Style::Display(Display::None),
-                            importance: decl.important,
-                        });
-                    }
-                    #[cfg(feature = "css_ext")]
-                    parser::Display::RawDom => {
-                        styles.push(StyleDecl {
-                            style: Style::Display(Display::ExtRawDom),
-                            importance: decl.important,
-                        });
-                    }
-                    _ => (),
+            parser::Decl::Display { value } => match value {
+                parser::Display::None => {
+                    styles.push(StyleDecl {
+                        style: Style::Display(Display::None),
+                        importance: decl.important,
+                    });
                 }
-            }
+                #[cfg(feature = "css_ext")]
+                parser::Display::RawDom => {
+                    styles.push(StyleDecl {
+                        style: Style::Display(Display::ExtRawDom),
+                        importance: decl.important,
+                    });
+                }
+                _ => (),
+            },
             parser::Decl::WhiteSpace { value } => {
                 styles.push(StyleDecl {
                     style: Style::WhiteSpace(*value),

--- a/src/css/parser.rs
+++ b/src/css/parser.rs
@@ -61,6 +61,8 @@ pub(crate) enum Overflow {
 pub(crate) enum Display {
     None,
     Other,
+    #[cfg(feature = "css_ext")]
+    RawDom,
 }
 
 #[derive(Debug, PartialEq)]
@@ -715,6 +717,8 @@ fn parse_display(value: &RawValue) -> Result<Display, nom::Err<nom::error::Error
             #[allow(clippy::single_match)]
             match word.deref() {
                 "none" => return Ok(Display::None),
+                #[cfg(feature = "css_ext")]
+                "x-raw-dom" => return Ok(Display::RawDom),
                 _ => (),
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,6 @@ mod macros;
 pub mod css;
 pub mod render;
 
-use css::Display;
 use render::text_renderer::{
     RenderLine, RenderOptions, RichAnnotation, SubRenderer, TaggedLine, TextRenderer,
 };
@@ -1518,9 +1517,9 @@ fn process_dom_node<T: Write>(
                         .style_data
                         .computed_style(**parent_style, handle, context.use_doc_css);
                 match computed.display.val() {
-                    Some(Display::None) => return Ok(Nothing),
+                    Some(css::Display::None) => return Ok(Nothing),
                     #[cfg(feature = "css_ext")]
-                    Some(Display::ExtRawDom) => {
+                    Some(css::Display::ExtRawDom) => {
                         let result_text = RcDom::node_as_dom_string(handle);
                         let mut computed = computed;
                         computed.white_space.maybe_update(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,12 @@ pub struct Colour {
     pub b: u8,
 }
 
+impl std::fmt::Display for Colour {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "#{:02x}{:02x}{:02x}", self.r, self.g, self.b)
+    }
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default, PartialOrd)]
 pub(crate) enum StyleOrigin {
     #[default]
@@ -1364,6 +1370,15 @@ fn dom_to_render_tree_with_context<T: Write>(
 
     html_trace!("### dom_to_render_tree: out= {:#?}", result);
     result
+}
+
+#[cfg(feature = "css")]
+/// Return a string representation of the CSS rules parsed from
+/// the DOM document.
+pub fn dom_to_parsed_style(dom: &RcDom) -> Result<String> {
+    let handle = dom.document.clone();
+    let doc_style_data = css::dom_to_stylesheet(handle, &mut std::io::sink())?;
+    Ok(doc_style_data.to_string())
 }
 
 fn pending<F>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1530,7 +1530,10 @@ fn process_dom_node<T: Write>(
                             WhiteSpace::Pre,
                         );
                         let text = RenderNode::new(RenderNodeInfo::Text(result_text));
-                        return Ok(Finished(RenderNode::new_styled(RenderNodeInfo::Block(vec![text]), computed)));
+                        return Ok(Finished(RenderNode::new_styled(
+                            RenderNodeInfo::Block(vec![text]),
+                            computed,
+                        )));
                     }
                     _ => (),
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,28 @@ impl Specificity {
     }
 }
 
+impl std::ops::Add<&Specificity> for &Specificity {
+    type Output = Specificity;
+
+    fn add(self, rhs: &Specificity) -> Self::Output {
+        Specificity {
+            inline: self.inline || rhs.inline,
+            id: self.id + rhs.id,
+            class: self.class + rhs.class,
+            typ: self.typ + rhs.typ,
+        }
+    }
+}
+
+impl std::ops::AddAssign<&Specificity> for Specificity {
+    fn add_assign(&mut self, rhs: &Specificity) {
+        self.inline = self.inline || rhs.inline;
+        self.id += rhs.id;
+        self.class += rhs.class;
+        self.typ += rhs.typ;
+    }
+}
+
 impl PartialOrd for Specificity {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         match self.inline.partial_cmp(&other.inline) {

--- a/src/markup5ever_rcdom.rs
+++ b/src/markup5ever_rcdom.rs
@@ -284,6 +284,26 @@ impl RcDom {
         Self::add_node_to_string(&mut s, &self.document, 0);
         s
     }
+
+    /// A low-quality debug DOM rendering of an individual node
+    pub fn node_as_dom_string(node: &Handle) -> String {
+        let mut s = String::new();
+        Self::add_node_to_string(&mut s, node, 0);
+        s
+    }
+
+    /// Find the node at a child path starting from the root element.  At each level, 1 is the
+    /// first child element, and only elements are counted.
+    pub fn get_node_by_path(&self, path: &[usize]) -> Option<Handle> {
+        let mut node = self.document.clone();
+        for idx in path {
+            node = match node.nth_child(*idx) {
+                Some(new_node) => new_node,
+                None => return None,
+            };
+        }
+        Some(node)
+    }
 }
 
 impl TreeSink for RcDom {

--- a/src/render/text_renderer.rs
+++ b/src/render/text_renderer.rs
@@ -318,7 +318,6 @@ impl<T: Debug + Eq + PartialEq + Clone + Default> TaggedLine<T> {
 struct WrappedBlock<T> {
     width: usize,
     text: Vec<TaggedLine<T>>,
-    textlen: usize,
     line: TaggedLine<T>,
     spacetag: Option<T>, // Tag for the whitespace before the current word
     word: TaggedLine<T>, // The current word (with no whitespace).
@@ -334,7 +333,6 @@ impl<T: Clone + Eq + Debug + Default> WrappedBlock<T> {
         WrappedBlock {
             width,
             text: Vec::new(),
-            textlen: 0,
             line: TaggedLine::new(),
             spacetag: None,
             word: TaggedLine::new(),
@@ -646,7 +644,7 @@ impl<T: Clone + Eq + Debug + Default> WrappedBlock<T> {
     }
 
     fn text_len(&self) -> usize {
-        self.textlen + self.line.len + self.wordlen
+        self.text.len() + self.line.len + self.wordlen
     }
 
     fn is_empty(&self) -> bool {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2643,4 +2643,128 @@ at  line  breaks
             },
         );
     }
+
+    #[test]
+    fn test_nth_child() {
+        test_html_coloured(
+            br#"
+          <style>
+              li:nth-child(even) {
+                  color: #f00;
+              }
+          </style>
+          <body><ul>
+              <li>One</li>
+              <li>Two</li>
+              <li>Three</li>
+              <li>Four</li>
+              <li>Five</li>
+          </ul>"#,
+            r#"* One
+* <R>Two</R>
+* Three
+* <R>Four</R>
+* Five
+"#,
+            20,
+        );
+        test_html_coloured(
+            br#"
+          <style>
+              li:nth-child(odd) {
+                  color: #f00;
+              }
+          </style>
+          <body><ul>
+              <li>One</li>
+              <li>Two</li>
+              <li>Three</li>
+              <li>Four</li>
+              <li>Five</li>
+          </ul>"#,
+            r#"* <R>One</R>
+* Two
+* <R>Three</R>
+* Four
+* <R>Five</R>
+"#,
+            20,
+        );
+        test_html_coloured(
+            br#"
+          <style>
+              li:nth-child(-n+3) {
+                  color: #f00;
+              }
+          </style>
+          <body><ul>
+              <li>One</li>
+              <li>Two</li>
+              <li>Three</li>
+              <li>Four</li>
+              <li>Five</li>
+          </ul>"#,
+            r#"* <R>One</R>
+* <R>Two</R>
+* <R>Three</R>
+* Four
+* Five
+"#,
+            20,
+        );
+        test_html_coloured(
+            br#"
+          <style>
+              li:nth-child(2) {
+                  color: #f00;
+              }
+          </style>
+          <body><ul>
+              <li>One</li>
+              <li>Two</li>
+              <li>Three</li>
+              <li>Four</li>
+              <li>Five</li>
+          </ul>"#,
+            r#"* One
+* <R>Two</R>
+* Three
+* Four
+* Five
+"#,
+            20,
+        );
+        test_html_coloured(
+            br#"
+          <style>
+              li:nth-child(n+3):nth-child(-n+5) {
+                  color: #f00;
+              }
+          </style>
+          <body><ul>
+              <li>One</li>
+              <li>Two</li>
+              <li>Three</li>
+              <li>Four</li>
+              <li>Five</li>
+              <li>Six</li>
+              <li>Seven</li>
+              <li>Eight</li>
+              <li>Nine</li>
+              <li>Ten</li>
+          </ul>"#,
+            r#"* One
+* Two
+* <R>Three</R>
+* <R>Four</R>
+* <R>Five</R>
+* Six
+* Seven
+* Eight
+* Nine
+* Ten
+"#,
+            20,
+        );
+    }
 }


### PR DESCRIPTION
This allows a simple debug mode where a portion of the document is shown as the raw DOM rather than rendered normally.
Also a couple of bug fixes.