### PR TITLE
Refactors

### DIFF
--- a/examples/html2term.rs
+++ b/examples/html2term.rs
@@ -269,21 +269,17 @@ mod top {
                     Key::Char('k') | Key::Up => {
                         if inspect_path.is_empty() {
                             doc_y = doc_y.saturating_sub(1);
-                        } else {
-                            if *inspect_path.last().unwrap() > 1 {
-                                *inspect_path.last_mut().unwrap() -= 1;
-                                annotated = rerender(&dom, &inspect_path, width, &options);
-                            }
+                        } else if *inspect_path.last().unwrap() > 1 {
+                            *inspect_path.last_mut().unwrap() -= 1;
+                            annotated = rerender(&dom, &inspect_path, width, &options);
                         }
                     }
                     Key::Char('h') | Key::Left => {
                         if inspect_path.is_empty() {
                             doc_x = doc_x.saturating_sub(1);
-                        } else {
-                            if inspect_path.len() > 1 {
-                                inspect_path.pop();
-                                annotated = rerender(&dom, &inspect_path, width, &options);
-                            }
+                        } else if inspect_path.len() > 1 {
+                            inspect_path.pop();
+                            annotated = rerender(&dom, &inspect_path, width, &options);
                         }
                     }
                     Key::Char('l') | Key::Right => {
@@ -378,7 +374,7 @@ mod top {
         };
         if inspect_path.is_empty() {
             let render_tree = config
-                .dom_to_render_tree(&dom)
+                .dom_to_render_tree(dom)
                 .expect("Failed to build render tree");
             config
                 .render_to_lines(render_tree, width)
@@ -405,7 +401,7 @@ mod top {
                     )
                     .expect("Invalid CSS");
                 let render_tree = config
-                    .dom_to_render_tree(&dom)
+                    .dom_to_render_tree(dom)
                     .expect("Failed to build render tree");
                 config
                     .render_to_lines(render_tree, width)

--- a/src/ansi_colours.rs
+++ b/src/ansi_colours.rs
@@ -8,6 +8,7 @@ use crate::{parse, RichAnnotation, RichDecorator};
 use std::io;
 
 /// Reads HTML from `input`, and returns text wrapped to `width` columns.
+///
 /// The text is returned as a `Vec<TaggedLine<_>>`; the annotations are vectors
 /// of `RichAnnotation`.  The "outer" annotation comes first in the `Vec`.
 ///

--- a/src/ansi_colours.rs
+++ b/src/ansi_colours.rs
@@ -4,7 +4,7 @@
 //! can be achieved using inline characters sent to the terminal such as
 //! underlining in some terminals).
 
-use crate::{parse, RichAnnotation, RichDecorator};
+use crate::RichAnnotation;
 use std::io;
 
 /// Reads HTML from `input`, and returns text wrapped to `width` columns.
@@ -25,16 +25,5 @@ where
     R: io::Read,
     FMap: Fn(&[RichAnnotation], &str) -> String,
 {
-    let lines = parse(input)?
-        .render(width, RichDecorator::new())?
-        .into_lines()?;
-
-    let mut result = String::new();
-    for line in lines {
-        for ts in line.tagged_strings() {
-            result.push_str(&colour_map(&ts.tag, &ts.s));
-        }
-        result.push('\n');
-    }
-    Ok(result)
+    super::config::rich().coloured(input, width, colour_map)
 }

--- a/src/css.rs
+++ b/src/css.rs
@@ -132,10 +132,8 @@ impl Selector {
                                 if Rc::ptr_eq(child, node) {
                                     break;
                                 }
-                            } else {
-                                if Rc::ptr_eq(child, node) {
-                                    return false;
-                                }
+                            } else if Rc::ptr_eq(child, node) {
+                                return false;
                             }
                         }
                     }
@@ -148,14 +146,14 @@ impl Selector {
                      */
                     let idx_offset = idx - b;
                     if *a == 0 {
-                        return idx_offset == 0 && Self::do_matches(&comps[1..], &node);
+                        return idx_offset == 0 && Self::do_matches(&comps[1..], node);
                     }
                     if (idx_offset % a) != 0 {
                         // Not a multiple
                         return false;
                     }
                     let n = idx_offset / a;
-                    n >= 0 && Self::do_matches(&comps[1..], &node)
+                    n >= 0 && Self::do_matches(&comps[1..], node)
                 }
             },
         }

--- a/src/css.rs
+++ b/src/css.rs
@@ -16,7 +16,7 @@ use crate::{
 
 use self::parser::Importance;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum SelectorComponent {
     Class(String),
     Element(String),
@@ -46,7 +46,7 @@ impl std::fmt::Display for SelectorComponent {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct Selector {
     // List of components, right first so we match from the leaf.
     components: Vec<SelectorComponent>,
@@ -189,7 +189,7 @@ impl Selector {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Display {
     /// display: none
     None,
@@ -198,7 +198,7 @@ pub(crate) enum Display {
     ExtRawDom,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum Style {
     Colour(Colour),
     BgColour(Colour),
@@ -206,7 +206,7 @@ pub(crate) enum Style {
     WhiteSpace(WhiteSpace),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct StyleDecl {
     style: Style,
     importance: Importance,
@@ -230,7 +230,7 @@ impl std::fmt::Display for StyleDecl {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct Ruleset {
     selector: Selector,
     styles: Vec<StyleDecl>,
@@ -248,7 +248,7 @@ impl std::fmt::Display for Ruleset {
 }
 
 /// Stylesheet data which can be used while building the render tree.
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
 pub(crate) struct StyleData {
     agent_rules: Vec<Ruleset>,
     user_rules: Vec<Ruleset>,

--- a/src/css/parser.rs
+++ b/src/css/parser.rs
@@ -397,13 +397,11 @@ fn parse_faulty_color(
     text: &str,
 ) -> Result<Colour, nom::Err<nom::error::Error<&'static str>>> {
     let text = text.trim();
-    if text.chars().all(|c| c.is_hex_digit()) {
-        if text.len() == 6 {
-            let r = u8::from_str_radix(&text[0..2], 16).unwrap();
-            let g = u8::from_str_radix(&text[2..4], 16).unwrap();
-            let b = u8::from_str_radix(&text[4..6], 16).unwrap();
-            return Ok(Colour::Rgb(r, g, b));
-        }
+    if text.chars().all(|c| c.is_hex_digit()) && text.len() == 6 {
+        let r = u8::from_str_radix(&text[0..2], 16).unwrap();
+        let g = u8::from_str_radix(&text[2..4], 16).unwrap();
+        let b = u8::from_str_radix(&text[4..6], 16).unwrap();
+        return Ok(Colour::Rgb(r, g, b));
     }
     Err(e)
 }

--- a/src/css/parser.rs
+++ b/src/css/parser.rs
@@ -390,6 +390,10 @@ pub(crate) fn parse_color_attribute(
     parse_color(&value.tokens).or_else(|e| parse_faulty_color(e, text))
 }
 
+fn parse_color_part(text: &str, index: std::ops::Range<usize>) -> Option<u8> {
+    u8::from_str_radix(text.get(index)?, 16).ok()
+}
+
 // Both Firefox and Chromium accept "00aabb" as a bgcolor - I'm not sure this has ever been legal,
 // but regrettably I've had e-mails which were unreadable without doing this.
 fn parse_faulty_color(
@@ -397,10 +401,10 @@ fn parse_faulty_color(
     text: &str,
 ) -> Result<Colour, nom::Err<nom::error::Error<&'static str>>> {
     let text = text.trim();
-    if text.chars().all(|c| c.is_hex_digit()) && text.len() == 6 {
-        let r = u8::from_str_radix(&text[0..2], 16).unwrap();
-        let g = u8::from_str_radix(&text[2..4], 16).unwrap();
-        let b = u8::from_str_radix(&text[4..6], 16).unwrap();
+    let r = parse_color_part(text, 0..2);
+    let g = parse_color_part(text, 2..4);
+    let b = parse_color_part(text, 4..6);
+    if let (Some(r), Some(g), Some(b)) = (r, g, b) {
         return Ok(Colour::Rgb(r, g, b));
     }
     Err(e)
@@ -618,7 +622,7 @@ fn parse_string_token(text: &str) -> IResult<&str, Token> {
 
     loop {
         match chars.next() {
-            None => return Ok((&text[text.len()..], Token::String(s.into()))),
+            None => return Ok(("", Token::String(s.into()))),
             Some((i, c)) if c == end_char => {
                 return Ok((&text[i + 1..], Token::String(s.into())));
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ use std::io;
 use std::io::Write;
 use std::iter::{once, repeat};
 
-#[derive(Debug, Copy, Clone, Default, PartialEq)]
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
 pub(crate) enum WhiteSpace {
     #[default]
     Normal,
@@ -1306,7 +1306,7 @@ where
     }
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, PartialEq, Eq)]
 struct HtmlContext {
     #[cfg(feature = "css")]
     style_data: css::StyleData,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2371,7 +2371,10 @@ pub mod config {
             }
         }
         /// Parse with context.
-        fn do_parse<R: io::Read>(&self, context: &mut HtmlContext, input: R) -> Result<RenderTree> {
+        pub(crate) fn do_parse<R>(&self, context: &mut HtmlContext, input: R) -> Result<RenderTree>
+        where
+            R: io::Read,
+        {
             super::parse_with_context(input, context)
         }
 
@@ -2682,8 +2685,8 @@ fn parse_with_context(input: impl io::Read, context: &mut HtmlContext) -> Result
 
 /// Reads and parses HTML from `input` and prepares a render tree.
 pub fn parse(input: impl io::Read) -> Result<RenderTree> {
-    let mut context = config::plain().make_context();
-    parse_with_context(input, &mut context)
+    let cfg = config::plain();
+    cfg.do_parse(&mut cfg.make_context(), input)
 }
 
 /// Reads HTML from `input`, decorates it using `decorator`, and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ pub mod render;
 use render::text_renderer::{
     RenderLine, RenderOptions, RichAnnotation, SubRenderer, TaggedLine, TextRenderer,
 };
-use render::{Renderer, RichDecorator, TextDecorator};
+use render::{Renderer, TextDecorator};
 
 use html5ever::driver::ParseOpts;
 use html5ever::parse_document;
@@ -2371,11 +2371,7 @@ pub mod config {
             }
         }
         /// Parse with context.
-        fn do_parse<R: io::Read>(
-            &mut self,
-            context: &mut HtmlContext,
-            input: R,
-        ) -> Result<RenderTree> {
+        fn do_parse<R: io::Read>(&self, context: &mut HtmlContext, input: R) -> Result<RenderTree> {
             super::parse_with_context(input, context)
         }
 
@@ -2438,11 +2434,7 @@ pub mod config {
 
         /// Reads HTML from `input`, and returns a `String` with text wrapped to
         /// `width` columns.
-        pub fn string_from_read<R: std::io::Read>(
-            mut self,
-            input: R,
-            width: usize,
-        ) -> Result<String> {
+        pub fn string_from_read<R: std::io::Read>(self, input: R, width: usize) -> Result<String> {
             let mut context = self.make_context();
             let s = self
                 .do_parse(&mut context, input)?
@@ -2456,7 +2448,7 @@ pub mod config {
         /// of the provided text decorator's `Annotation`.  The "outer" annotation comes first in
         /// the `Vec`.
         pub fn lines_from_read<R: std::io::Read>(
-            mut self,
+            self,
             input: R,
             width: usize,
         ) -> Result<Vec<TaggedLine<Vec<D::Annotation>>>> {
@@ -2548,12 +2540,7 @@ pub mod config {
         /// a list of `RichAnnotation` and some text, and returns the text
         /// with any terminal escapes desired to indicate those annotations
         /// (such as colour).
-        pub fn coloured<R, FMap>(
-            mut self,
-            input: R,
-            width: usize,
-            colour_map: FMap,
-        ) -> Result<String>
+        pub fn coloured<R, FMap>(self, input: R, width: usize, colour_map: FMap) -> Result<String>
         where
             R: std::io::Read,
             FMap: Fn(&[RichAnnotation], &str) -> String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1306,7 +1306,7 @@ where
     }
 }
 
-#[derive(Default, Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 struct HtmlContext {
     #[cfg(feature = "css")]
     style_data: css::StyleData,
@@ -2354,7 +2354,7 @@ pub mod config {
 
     impl<D: TextDecorator> Config<D> {
         /// Make the HtmlContext from self.
-        fn make_context(&self) -> HtmlContext {
+        pub(crate) fn make_context(&self) -> HtmlContext {
             HtmlContext {
                 #[cfg(feature = "css")]
                 style_data: self.style.clone(),
@@ -2646,7 +2646,8 @@ impl RenderTree {
 
     /// Render this document using the given `decorator` and wrap it to `width` columns.
     fn render<D: TextDecorator>(self, width: usize, decorator: D) -> Result<RenderedText<D>> {
-        self.render_with_context(&mut Default::default(), width, decorator)
+        let mut context = config::plain().make_context();
+        self.render_with_context(&mut context, width, decorator)
     }
 }
 
@@ -2681,7 +2682,8 @@ fn parse_with_context(input: impl io::Read, context: &mut HtmlContext) -> Result
 
 /// Reads and parses HTML from `input` and prepares a render tree.
 pub fn parse(input: impl io::Read) -> Result<RenderTree> {
-    parse_with_context(input, &mut Default::default())
+    let mut context = config::plain().make_context();
+    parse_with_context(input, &mut context)
 }
 
 /// Reads HTML from `input`, decorates it using `decorator`, and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2653,12 +2653,6 @@ impl RenderTree {
             render_tree_to_string(context, builder, &test_decorator, self.0, &mut io::sink())?;
         Ok(RenderedText(builder))
     }
-
-    /// Render this document using the given `decorator` and wrap it to `width` columns.
-    fn render<D: TextDecorator>(self, width: usize, decorator: D) -> Result<RenderedText<D>> {
-        let mut context = config::plain().make_context();
-        self.render_with_context(&mut context, width, decorator)
-    }
 }
 
 /// A rendered HTML document.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2601,38 +2601,12 @@ pub mod config {
 
     /// Return a Config initialized with a `RichDecorator`.
     pub fn rich() -> Config<RichDecorator> {
-        Config {
-            decorator: RichDecorator::new(),
-            #[cfg(feature = "css")]
-            style: Default::default(),
-            #[cfg(feature = "css")]
-            use_doc_css: false,
-            max_wrap_width: None,
-            pad_block_width: false,
-            allow_width_overflow: false,
-            min_wrap_width: MIN_WIDTH,
-            raw: false,
-            draw_borders: true,
-            wrap_links: true,
-        }
+        with_decorator(RichDecorator::new())
     }
 
     /// Return a Config initialized with a `PlainDecorator`.
     pub fn plain() -> Config<PlainDecorator> {
-        Config {
-            decorator: PlainDecorator::new(),
-            #[cfg(feature = "css")]
-            style: Default::default(),
-            #[cfg(feature = "css")]
-            use_doc_css: false,
-            max_wrap_width: None,
-            pad_block_width: false,
-            allow_width_overflow: false,
-            min_wrap_width: MIN_WIDTH,
-            raw: false,
-            draw_borders: true,
-            wrap_links: true,
-        }
+        with_decorator(PlainDecorator::new())
     }
 
     /// Return a Config initialized with a custom decorator.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,6 @@ use render::{Renderer, RichDecorator, TextDecorator};
 
 use html5ever::driver::ParseOpts;
 use html5ever::parse_document;
-use html5ever::tendril::TendrilSink;
 use html5ever::tree_builder::TreeBuilderOpts;
 mod markup5ever_rcdom;
 pub use markup5ever_rcdom::RcDom;
@@ -2722,17 +2721,8 @@ impl<D: TextDecorator> RenderedText<D> {
     }
 }
 
-fn parse_with_context(mut input: impl io::Read, context: &mut HtmlContext) -> Result<RenderTree> {
-    let opts = ParseOpts {
-        tree_builder: TreeBuilderOpts {
-            drop_doctype: true,
-            ..Default::default()
-        },
-        ..Default::default()
-    };
-    let dom = parse_document(RcDom::default(), opts)
-        .from_utf8()
-        .read_from(&mut input)?;
+fn parse_with_context(input: impl io::Read, context: &mut HtmlContext) -> Result<RenderTree> {
+    let dom = config::plain().parse_html(input)?;
     let render_tree =
         dom_to_render_tree_with_context(dom.document.clone(), &mut io::sink(), context)?
             .ok_or(Error::Fail)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2546,19 +2546,8 @@ pub mod config {
             FMap: Fn(&[RichAnnotation], &str) -> String,
         {
             let mut context = self.make_context();
-            let lines = self
-                .do_parse(&mut context, input)?
-                .render_with_context(&mut context, width, self.decorator)?
-                .into_lines()?;
-
-            let mut result = String::new();
-            for line in lines {
-                for ts in line.tagged_strings() {
-                    result.push_str(&colour_map(&ts.tag, &ts.s));
-                }
-                result.push('\n');
-            }
-            Ok(result)
+            let render_tree = self.do_parse(&mut context, input)?;
+            self.render_coloured(render_tree, width, colour_map)
         }
 
         /// Return coloured text from a RenderTree.  `colour_map` is a function which takes a list

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -846,7 +846,7 @@ impl RenderNode {
         if style.internal_pre {
             write!(f, " internal_pre")?;
         }
-        writeln!(f, "")
+        writeln!(f)
     }
     fn write_self(
         &self,
@@ -858,52 +858,52 @@ impl RenderNode {
         match &self.info {
             RenderNodeInfo::Text(s) => writeln!(f, "{:indent$}{s:?}", "")?,
             RenderNodeInfo::Container(v) => {
-                self.write_container("Container", &v, f, indent)?;
+                self.write_container("Container", v, f, indent)?;
             }
             RenderNodeInfo::Link(targ, v) => {
-                self.write_container(&format!("Link({})", targ), &v, f, indent)?;
+                self.write_container(&format!("Link({})", targ), v, f, indent)?;
             }
             RenderNodeInfo::Em(v) => {
-                self.write_container("Em", &v, f, indent)?;
+                self.write_container("Em", v, f, indent)?;
             }
             RenderNodeInfo::Strong(v) => {
-                self.write_container("Strong", &v, f, indent)?;
+                self.write_container("Strong", v, f, indent)?;
             }
             RenderNodeInfo::Strikeout(v) => {
-                self.write_container("Strikeout", &v, f, indent)?;
+                self.write_container("Strikeout", v, f, indent)?;
             }
             RenderNodeInfo::Code(v) => {
-                self.write_container("Code", &v, f, indent)?;
+                self.write_container("Code", v, f, indent)?;
             }
             RenderNodeInfo::Img(src, title) => {
                 writeln!(f, "{:indent$}Img src={:?} title={:?}:", "", src, title)?;
             }
             RenderNodeInfo::Block(v) => {
-                self.write_container("Block", &v, f, indent)?;
+                self.write_container("Block", v, f, indent)?;
             }
             RenderNodeInfo::Header(depth, v) => {
-                self.write_container(&format!("Header({})", depth), &v, f, indent)?;
+                self.write_container(&format!("Header({})", depth), v, f, indent)?;
             }
             RenderNodeInfo::Div(v) => {
-                self.write_container("Div", &v, f, indent)?;
+                self.write_container("Div", v, f, indent)?;
             }
             RenderNodeInfo::BlockQuote(v) => {
-                self.write_container("BlockQuote", &v, f, indent)?;
+                self.write_container("BlockQuote", v, f, indent)?;
             }
             RenderNodeInfo::Ul(v) => {
-                self.write_container("Ul", &v, f, indent)?;
+                self.write_container("Ul", v, f, indent)?;
             }
             RenderNodeInfo::Ol(start, v) => {
-                self.write_container(&format!("Ol({})", start), &v, f, indent)?;
+                self.write_container(&format!("Ol({})", start), v, f, indent)?;
             }
             RenderNodeInfo::Dl(v) => {
-                self.write_container("Dl", &v, f, indent)?;
+                self.write_container("Dl", v, f, indent)?;
             }
             RenderNodeInfo::Dt(v) => {
-                self.write_container("Dt", &v, f, indent)?;
+                self.write_container("Dt", v, f, indent)?;
             }
             RenderNodeInfo::Dd(v) => {
-                self.write_container("Dd", &v, f, indent)?;
+                self.write_container("Dd", v, f, indent)?;
             }
             RenderNodeInfo::Break => {
                 writeln!(f, "{:indent$}Break", "", indent = indent)?;
@@ -942,10 +942,10 @@ impl RenderNode {
                 writeln!(f, "{:indent$}FragStart({}):", "", frag)?;
             }
             RenderNodeInfo::ListItem(v) => {
-                self.write_container("ListItem", &v, f, indent)?;
+                self.write_container("ListItem", v, f, indent)?;
             }
             RenderNodeInfo::Sup(v) => {
-                self.write_container("Sup", &v, f, indent)?;
+                self.write_container("Sup", v, f, indent)?;
             }
         }
         Ok(())
@@ -2764,6 +2764,7 @@ where
 }
 
 /// Reads HTML from `input`, and returns text wrapped to `width` columns.
+///
 /// The text is returned as a `Vec<TaggedLine<_>>`; the annotations are vectors
 /// of `RichAnnotation`.  The "outer" annotation comes first in the `Vec`.
 pub fn from_read_rich<R>(input: R, width: usize) -> Result<Vec<TaggedLine<Vec<RichAnnotation>>>>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2375,7 +2375,7 @@ pub mod config {
         where
             R: io::Read,
         {
-            let dom = plain().parse_html(input)?;
+            let dom = self.parse_html(input)?;
             let render_tree = super::dom_to_render_tree_with_context(
                 dom.document.clone(),
                 &mut io::sink(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2375,7 +2375,14 @@ pub mod config {
         where
             R: io::Read,
         {
-            super::parse_with_context(input, context)
+            let dom = plain().parse_html(input)?;
+            let render_tree = super::dom_to_render_tree_with_context(
+                dom.document.clone(),
+                &mut io::sink(),
+                context,
+            )?
+            .ok_or(Error::Fail)?;
+            Ok(RenderTree(render_tree))
         }
 
         /// Parse the HTML into a DOM structure.
@@ -2673,14 +2680,6 @@ impl<D: TextDecorator> RenderedText<D> {
             .map(RenderLine::into_tagged_line)
             .collect())
     }
-}
-
-fn parse_with_context(input: impl io::Read, context: &mut HtmlContext) -> Result<RenderTree> {
-    let dom = config::plain().parse_html(input)?;
-    let render_tree =
-        dom_to_render_tree_with_context(dom.document.clone(), &mut io::sink(), context)?
-            .ok_or(Error::Fail)?;
-    Ok(RenderTree(render_tree))
 }
 
 /// Reads and parses HTML from `input` and prepares a render tree.

--- a/src/markup5ever_rcdom.rs
+++ b/src/markup5ever_rcdom.rs
@@ -151,7 +151,7 @@ impl Node {
     /// Return the element type (if an element)
     pub fn element_name(&self) -> Option<String> {
         if let NodeData::Element { ref name, .. } = self.data {
-            Some(format!("{}", &*name.local_name()))
+            Some(format!("{}", name.local_name()))
         } else {
             None
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1529,9 +1529,10 @@ fn test_finalise() {
             TestDecorator
         }
     }
-    let mut context = config::plain().make_context();
+    let cfg = config::plain();
+    let mut context = cfg.make_context();
     assert_eq!(
-        crate::parse("test".as_bytes())
+        cfg.do_parse(&mut context, "test".as_bytes())
             .unwrap()
             .render_with_context(&mut context, 80, TestDecorator)
             .unwrap()

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1529,14 +1529,9 @@ fn test_finalise() {
             TestDecorator
         }
     }
-    let cfg = config::plain();
-    let mut context = cfg.make_context();
     assert_eq!(
-        cfg.do_parse(&mut context, "test".as_bytes())
-            .unwrap()
-            .render_with_context(&mut context, 80, TestDecorator)
-            .unwrap()
-            .into_lines()
+        config::with_decorator(TestDecorator)
+            .lines_from_read("test".as_bytes(), 80)
             .unwrap(),
         vec![
             TaggedLine::from_string("test".to_owned(), &Vec::new()),
@@ -1935,10 +1930,9 @@ fn test_issue_93_x() {
         114, 104, 60, 47, 101, 109, 62, 60, 99, 99, 172, 97, 97, 58, 60, 119, 99, 64, 126, 118,
         104, 100, 100, 107, 105, 60, 120, 98, 255, 255, 255, 0, 60, 255, 127, 46, 60, 113, 127,
     ];
-    let _local0 = crate::parse(&data[..]).unwrap();
-    let d1 = TrivialDecorator::new();
-    let mut context = config::plain().make_context();
-    let _local1 = _local0.render_with_context(&mut context, 1, d1);
+    config::with_decorator(TrivialDecorator::new())
+        .string_from_read(&data[..], 1)
+        .unwrap_err();
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1529,11 +1529,11 @@ fn test_finalise() {
             TestDecorator
         }
     }
-
+    let mut context = config::plain().make_context();
     assert_eq!(
         crate::parse("test".as_bytes())
             .unwrap()
-            .render(80, TestDecorator)
+            .render_with_context(&mut context, 80, TestDecorator)
             .unwrap()
             .into_lines()
             .unwrap(),
@@ -1936,7 +1936,8 @@ fn test_issue_93_x() {
     ];
     let _local0 = crate::parse(&data[..]).unwrap();
     let d1 = TrivialDecorator::new();
-    let _local1 = crate::RenderTree::render(_local0, 1, d1);
+    let mut context = config::plain().make_context();
+    let _local1 = _local0.render_with_context(&mut context, 1, d1);
 }
 
 #[test]


### PR DESCRIPTION
These are the non-behavior-changing modifications from #191 

The original motivation for these changes is to streamline the way the library calls itself internally. We observed some slight mismatches between how the public API exposes the configurable stages and how the library passes information internally. We investigated whether those mismatches were a bug, but thankfully they were not. Still, the changes we suggest make this clearer by using higher-level functions where possible.