### PR TITLE
Add config::rich_no_decorate()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,6 @@ jobs:
           override: true
 
       - name: Check semver
-        uses: obi1kenobi/cargo-semver-checks-action@v1
+        uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           version-tag-prefix: ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Possible log types:
 
 ### Latest
 
+### 0.14.0
+
+- [changed] Various small refactors (thanks sftse)
+- [added] New `config::rich_no_decorate`, to use annotations without '\*' markers around 
+  bold text etc.
+
 ### 0.13.6
 
 - [fixed] Fixed issue parsing CSS rules with known rules but unknown values,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "html2text"
-version = "0.13.6"
+version = "0.14.0"
 authors = ["Chris Emerson <github@mail.nosreme.org>"]
 description = "Render HTML as plain text."
 repository = "https://github.com/jugglerchris/rust-html2text/"

--- a/examples/html2text.rs
+++ b/examples/html2text.rs
@@ -109,7 +109,11 @@ where
     #[cfg(unix)]
     {
         if flags.use_colour {
-            let conf = config::rich();
+            let conf = if flags.no_decorate {
+                config::rich_no_decorate()
+            } else {
+                config::rich()
+            };
             let conf = update_config(conf, &flags);
             #[cfg(feature = "css")]
             let use_css_colours = !flags.ignore_css_colours;
@@ -163,6 +167,8 @@ struct Flags {
     wrap_width: Option<usize>,
     #[allow(unused)]
     use_colour: bool,
+    #[allow(unused)]
+    no_decorate: bool,
     #[cfg(feature = "css")]
     use_css: bool,
     #[cfg(feature = "css")]
@@ -185,6 +191,7 @@ fn main() {
         width: 80,
         wrap_width: None,
         use_colour: false,
+        no_decorate: false,
         #[cfg(feature = "css")]
         use_css: false,
         #[cfg(feature = "css")]
@@ -230,6 +237,12 @@ fn main() {
             &["--colour"],
             StoreTrue,
             "Use ANSI terminal colours",
+        );
+        #[cfg(unix)]
+        ap.refer(&mut flags.no_decorate).add_option(
+            &["--no-decorate"],
+            StoreTrue,
+            "Skip decorations (with --colour)",
         );
         #[cfg(feature = "css")]
         ap.refer(&mut flags.use_css)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2590,6 +2590,11 @@ pub mod config {
         with_decorator(RichDecorator::new())
     }
 
+    /// Return a Config initialized with a `RichDecorator` and decoration disabled.
+    pub fn rich_no_decorate() -> Config<RichDecorator> {
+        with_decorator(RichDecorator::new_undecorated())
+    }
+
     /// Return a Config initialized with a `PlainDecorator`.
     pub fn plain() -> Config<PlainDecorator> {
         with_decorator(PlainDecorator::new())

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1394,6 +1394,17 @@ fn test_read_rich() {
 }
 
 #[test]
+fn test_read_rich_nodecorate() {
+    let html: &[u8] = b"<strong>bold</strong>";
+    let lines = config::rich_no_decorate()
+        .render_to_lines(parse(html).unwrap(), 80)
+        .unwrap();
+    let tag = vec![RichAnnotation::Strong];
+    let line = TaggedLine::from_string("bold".to_owned(), &tag);
+    assert_eq!(vec![line], lines);
+}
+
+#[test]
 fn test_read_custom() {
     let html: &[u8] = b"<strong>bold</strong>";
     let lines = config::with_decorator(TrivialDecorator::new())


### PR DESCRIPTION
This is similar to rich, but for things like bold and code blocks, don't include the textual decorations which can be handled by (for example) terminal attributes.