### PR TITLE
Use CSS for simple decorations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ Possible log types:
 ### 0.14.0
 
 - [changed] Various small refactors (thanks sftse)
-- [added] New `config::rich_no_decorate`, to use annotations without '\*' markers around 
-  bold text etc.
+- [changed] `Config::rich()` no longer includes decorations around `<em>` etc. - 
+  use `Config::rich().do_decorate()` to get the old behaviour.
 
 ### 0.13.6
 

--- a/examples/html2text.rs
+++ b/examples/html2text.rs
@@ -109,11 +109,7 @@ where
     #[cfg(unix)]
     {
         if flags.use_colour {
-            let conf = if flags.no_decorate {
-                config::rich_no_decorate()
-            } else {
-                config::rich()
-            };
+            let conf = config::rich();
             let conf = update_config(conf, &flags);
             #[cfg(feature = "css")]
             let use_css_colours = !flags.ignore_css_colours;

--- a/examples/html2text.rs
+++ b/examples/html2text.rs
@@ -163,8 +163,6 @@ struct Flags {
     wrap_width: Option<usize>,
     #[allow(unused)]
     use_colour: bool,
-    #[allow(unused)]
-    no_decorate: bool,
     #[cfg(feature = "css")]
     use_css: bool,
     #[cfg(feature = "css")]
@@ -187,7 +185,6 @@ fn main() {
         width: 80,
         wrap_width: None,
         use_colour: false,
-        no_decorate: false,
         #[cfg(feature = "css")]
         use_css: false,
         #[cfg(feature = "css")]
@@ -233,12 +230,6 @@ fn main() {
             &["--colour"],
             StoreTrue,
             "Use ANSI terminal colours",
-        );
-        #[cfg(unix)]
-        ap.refer(&mut flags.no_decorate).add_option(
-            &["--no-decorate"],
-            StoreTrue,
-            "Skip decorations (with --colour)",
         );
         #[cfg(feature = "css")]
         ap.refer(&mut flags.use_css)

--- a/src/css.rs
+++ b/src/css.rs
@@ -1,22 +1,28 @@
 //! Some basic CSS support.
 use std::ops::Deref;
-use std::{io::Write, rc::Rc};
+use std::rc::Rc;
 
+#[cfg(feature = "css")]
 mod parser;
+pub(crate) mod types;
+
+#[cfg(feature = "css")]
+use crate::{Colour, Result, WhiteSpace};
+#[cfg(feature = "css")]
+use parser::parse_style_attribute;
+
+use types::Importance;
 
 use crate::{
-    css::parser::parse_rules,
     markup5ever_rcdom::{
         Handle,
         NodeData::{self, Comment, Document, Element},
     },
-    tree_map_reduce, Colour, ComputedStyle, Result, Specificity, StyleOrigin, TreeMapResult,
-    WhiteSpace,
+    ComputedStyle, Specificity, StyleOrigin,
 };
 
-use self::parser::Importance;
-
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(unused)]
 pub(crate) enum SelectorComponent {
     Class(String),
     Element(String),
@@ -55,8 +61,8 @@ impl std::fmt::Display for SelectorComponent {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub(crate) struct Selector {
     // List of components, right first so we match from the leaf.
-    components: Vec<SelectorComponent>,
-    pseudo_element: Option<PseudoElement>,
+    pub(crate) components: Vec<SelectorComponent>,
+    pub(crate) pseudo_element: Option<PseudoElement>,
 }
 
 impl std::fmt::Display for Selector {
@@ -201,6 +207,7 @@ impl Selector {
     }
 }
 
+#[cfg(feature = "css")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Display {
     /// display: none
@@ -218,29 +225,41 @@ pub(crate) struct PseudoContent {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum Style {
+    #[cfg(feature = "css")]
     Colour(Colour),
+    #[cfg(feature = "css")]
     BgColour(Colour),
+    #[cfg(feature = "css")]
     Display(Display),
+    #[cfg(feature = "css")]
     WhiteSpace(WhiteSpace),
     Content(PseudoContent),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct StyleDecl {
-    style: Style,
-    importance: Importance,
+    pub(crate) style: Style,
+    pub(crate) importance: Importance,
 }
 
 impl std::fmt::Display for StyleDecl {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.style {
+        match &self.style {
+            #[cfg(feature = "css")]
             Style::Colour(col) => write!(f, "color: {}", col)?,
+            #[cfg(feature = "css")]
             Style::BgColour(col) => write!(f, "background-color: {}", col)?,
+            #[cfg(feature = "css")]
             Style::Display(Display::None) => write!(f, "display: none")?,
             #[cfg(feature = "css_ext")]
             Style::Display(Display::ExtRawDom) => write!(f, "display: x-raw-dom")?,
-            Style::WhiteSpace(_) => todo!(),
-            Style::Content(_) => todo!(),
+            #[cfg(feature = "css")]
+            Style::WhiteSpace(ws) => match ws {
+                WhiteSpace::Normal => write!(f, "white-space: normal")?,
+                WhiteSpace::Pre => write!(f, "white-space: pre")?,
+                WhiteSpace::PreWrap => write!(f, "white-space: pre-wrap")?,
+            },
+            Style::Content(content) => write!(f, "content: \"{}\"", content.text)?,
         }
         match self.importance {
             Importance::Default => (),
@@ -251,9 +270,9 @@ impl std::fmt::Display for StyleDecl {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct Ruleset {
-    selector: Selector,
-    styles: Vec<StyleDecl>,
+pub(crate) struct Ruleset {
+    pub(crate) selector: Selector,
+    pub(crate) styles: Vec<StyleDecl>,
 }
 
 impl std::fmt::Display for Ruleset {
@@ -275,15 +294,7 @@ pub(crate) struct StyleData {
     author_rules: Vec<Ruleset>,
 }
 
-pub(crate) fn parse_style_attribute(text: &str) -> Result<Vec<StyleDecl>> {
-    html_trace_quiet!("Parsing inline style: {text}");
-    let (_rest, decls) = parse_rules(text).map_err(|_| crate::Error::CssParseError)?;
-
-    let styles = styles_from_properties(&decls);
-    html_trace_quiet!("Parsed inline style: {:?}", styles);
-    Ok(styles)
-}
-
+#[cfg(feature = "css")]
 fn styles_from_properties(decls: &[parser::Declaration]) -> Vec<StyleDecl> {
     let mut styles = Vec::new();
     html_trace_quiet!("styles:from_properties2: {decls:?}");
@@ -369,12 +380,11 @@ fn styles_from_properties(decls: &[parser::Declaration]) -> Vec<StyleDecl> {
                     style: Style::Content(PseudoContent { text: text.clone() }),
                     importance: decl.important,
                 });
-            }
-            /*
-            _ => {
-                html_trace_quiet!("CSS: Unhandled property {:?}", decl);
-            }
-            */
+            } /*
+              _ => {
+                  html_trace_quiet!("CSS: Unhandled property {:?}", decl);
+              }
+              */
         }
     }
     // If the height is set to zero and overflow hidden, treat as display: none
@@ -388,6 +398,7 @@ fn styles_from_properties(decls: &[parser::Declaration]) -> Vec<StyleDecl> {
 }
 
 impl StyleData {
+    #[cfg(feature = "css")]
     /// Add some CSS source to be included.  The source will be parsed
     /// and the relevant and supported features extracted.
     fn do_add_css(css: &str, rules: &mut Vec<Ruleset>) -> Result<()> {
@@ -408,21 +419,32 @@ impl StyleData {
         }
         Ok(())
     }
+
+    pub(crate) fn add_agent_rules(&mut self, rules: &[Ruleset]) {
+        for rule in rules {
+            self.agent_rules.push(rule.clone());
+        }
+    }
+
+    #[cfg(feature = "css")]
     /// Add some CSS source to be included as part of the user agent ("browser") CSS rules.
     pub fn add_agent_css(&mut self, css: &str) -> Result<()> {
         Self::do_add_css(css, &mut self.agent_rules)
     }
 
+    #[cfg(feature = "css")]
     /// Add some CSS source to be included as part of the user CSS rules.
     pub fn add_user_css(&mut self, css: &str) -> Result<()> {
         Self::do_add_css(css, &mut self.user_rules)
     }
 
+    #[cfg(feature = "css")]
     /// Add some CSS source to be included as part of the document/author CSS rules.
     pub fn add_author_css(&mut self, css: &str) -> Result<()> {
         Self::do_add_css(css, &mut self.author_rules)
     }
 
+    #[cfg(feature = "css")]
     /// Merge style data from other into this one.
     /// Data on other takes precedence.
     pub fn merge(&mut self, other: Self) {
@@ -435,7 +457,7 @@ impl StyleData {
         &self,
         parent_style: &ComputedStyle,
         handle: &Handle,
-        use_doc_css: bool,
+        _use_doc_css: bool,
     ) -> ComputedStyle {
         let mut result = parent_style.inherit();
 
@@ -460,7 +482,8 @@ impl StyleData {
             }
         }
 
-        if use_doc_css {
+        #[cfg(feature = "css")]
+        if _use_doc_css {
             // Now look for a style attribute
             if let Element { attrs, .. } = &handle.data {
                 let borrowed = attrs.borrow();
@@ -528,9 +551,7 @@ impl StyleData {
                 // computing the parent yet.
                 result.content_before.get_or_insert_default()
             }
-            Some(PseudoElement::After) => {
-                result.content_after.get_or_insert_default()
-            }
+            Some(PseudoElement::After) => result.content_after.get_or_insert_default(),
         };
         // The increasing priority is:
         // * agent
@@ -543,22 +564,26 @@ impl StyleData {
         // replace the value if we haven't yet seen an !important rule, and
         // never afterwards.
         match style.style {
+            #[cfg(feature = "css")]
             Style::Colour(col) => {
                 result_target
                     .colour
                     .maybe_update(important, origin, specificity, col);
             }
+            #[cfg(feature = "css")]
             Style::BgColour(col) => {
                 result_target
                     .bg_colour
                     .maybe_update(important, origin, specificity, col);
             }
+            #[cfg(feature = "css")]
             Style::Display(disp) => {
                 // We don't have a "not DisplayNone" - we might need to fix this.
                 result_target
                     .display
                     .maybe_update(important, origin, specificity, disp);
             }
+            #[cfg(feature = "css")]
             Style::WhiteSpace(ws) => {
                 result_target
                     .white_space
@@ -597,82 +622,101 @@ impl std::fmt::Display for StyleData {
     }
 }
 
-fn pending<F>(handle: Handle, f: F) -> TreeMapResult<'static, (), Handle, Vec<String>>
-where
-    F: Fn(&mut (), Vec<Vec<String>>) -> Result<Option<Vec<String>>> + 'static,
-{
-    TreeMapResult::PendingChildren {
-        children: handle.children.borrow().clone(),
-        cons: Box::new(f),
-        prefn: None,
-        postfn: None,
-    }
-}
+#[cfg(feature = "css")]
+pub(crate) mod dom_extract {
+    use std::io::Write;
 
-fn combine_vecs(vecs: Vec<Vec<String>>) -> Vec<String> {
-    let mut it = vecs.into_iter();
-    let first = it.next();
-    match first {
-        None => Vec::new(),
-        Some(mut first) => {
-            for v in it {
-                first.extend(v.into_iter());
-            }
-            first
+    use crate::{
+        markup5ever_rcdom::{
+            Handle,
+            NodeData::{self, Comment, Document, Element},
+        },
+        tree_map_reduce, Result, TreeMapResult,
+    };
+
+    use super::StyleData;
+
+    fn pending<F>(handle: Handle, f: F) -> TreeMapResult<'static, (), Handle, Vec<String>>
+    where
+        F: Fn(&mut (), Vec<Vec<String>>) -> Result<Option<Vec<String>>> + 'static,
+    {
+        TreeMapResult::PendingChildren {
+            children: handle.children.borrow().clone(),
+            cons: Box::new(f),
+            prefn: None,
+            postfn: None,
         }
     }
-}
 
-fn extract_style_nodes<T: Write>(
-    handle: Handle,
-    _err_out: &mut T,
-) -> TreeMapResult<'static, (), Handle, Vec<String>> {
-    use TreeMapResult::*;
-
-    match handle.clone().data {
-        Document => pending(handle, |&mut (), cs| Ok(Some(combine_vecs(cs)))),
-        Comment { .. } => Nothing,
-        Element { ref name, .. } => {
-            match name.expanded() {
-                expanded_name!(html "style") => {
-                    let mut result = String::new();
-                    // Assume just a flat text node
-                    for child in handle.children.borrow().iter() {
-                        if let NodeData::Text { ref contents } = child.data {
-                            result += &contents.borrow();
-                        }
-                    }
-                    Finished(vec![result])
+    fn combine_vecs(vecs: Vec<Vec<String>>) -> Vec<String> {
+        let mut it = vecs.into_iter();
+        let first = it.next();
+        match first {
+            None => Vec::new(),
+            Some(mut first) => {
+                for v in it {
+                    first.extend(v.into_iter());
                 }
-                _ => pending(handle, |_, cs| Ok(Some(combine_vecs(cs)))),
+                first
             }
         }
-        NodeData::Text {
-            contents: ref _tstr,
-        } => Nothing,
-        _ => {
-            // NodeData doesn't have a Debug impl.
-            Nothing
+    }
+
+    fn extract_style_nodes<T: Write>(
+        handle: Handle,
+        _err_out: &mut T,
+    ) -> TreeMapResult<'static, (), Handle, Vec<String>> {
+        use TreeMapResult::*;
+
+        match handle.clone().data {
+            Document => pending(handle, |&mut (), cs| Ok(Some(combine_vecs(cs)))),
+            Comment { .. } => Nothing,
+            Element { ref name, .. } => {
+                match name.expanded() {
+                    expanded_name!(html "style") => {
+                        let mut result = String::new();
+                        // Assume just a flat text node
+                        for child in handle.children.borrow().iter() {
+                            if let NodeData::Text { ref contents } = child.data {
+                                result += &contents.borrow();
+                            }
+                        }
+                        Finished(vec![result])
+                    }
+                    _ => pending(handle, |_, cs| Ok(Some(combine_vecs(cs)))),
+                }
+            }
+            NodeData::Text {
+                contents: ref _tstr,
+            } => Nothing,
+            _ => {
+                // NodeData doesn't have a Debug impl.
+                Nothing
+            }
         }
+    }
+
+    /// Extract stylesheet data from document.
+    pub(crate) fn dom_to_stylesheet<T: Write>(
+        handle: Handle,
+        err_out: &mut T,
+    ) -> Result<StyleData> {
+        let styles = tree_map_reduce(&mut (), handle, |_, handle| {
+            Ok(extract_style_nodes(handle, err_out))
+        })?;
+
+        let mut result = StyleData::default();
+        if let Some(styles) = styles {
+            for css in styles {
+                // Ignore CSS parse errors.
+                let _ = result.add_author_css(&css);
+            }
+        }
+        Ok(result)
     }
 }
 
-/// Extract stylesheet data from document.
-pub(crate) fn dom_to_stylesheet<T: Write>(handle: Handle, err_out: &mut T) -> Result<StyleData> {
-    let styles = tree_map_reduce(&mut (), handle, |_, handle| {
-        Ok(extract_style_nodes(handle, err_out))
-    })?;
-
-    let mut result = StyleData::default();
-    if let Some(styles) = styles {
-        for css in styles {
-            // Ignore CSS parse errors.
-            let _ = result.add_author_css(&css);
-        }
-    }
-    Ok(result)
-}
-
+#[cfg(feature = "css")]
 #[cfg(test)]
 mod tests {
     use crate::Specificity;

--- a/src/css.rs
+++ b/src/css.rs
@@ -549,9 +549,9 @@ impl StyleData {
             Some(PseudoElement::Before) => {
                 // TODO: ideally we should inherit from the parent; however we haven't finished
                 // computing the parent yet.
-                result.content_before.get_or_insert_default()
+                result.content_before.get_or_insert_with(Default::default)
             }
-            Some(PseudoElement::After) => result.content_after.get_or_insert_default(),
+            Some(PseudoElement::After) => result.content_after.get_or_insert_with(Default::default),
         };
         // The increasing priority is:
         // * agent

--- a/src/css/parser.rs
+++ b/src/css/parser.rs
@@ -92,6 +92,9 @@ pub(crate) enum Decl {
     WhiteSpace {
         value: WhiteSpace,
     },
+    Content {
+        text: String,
+    },
     Unknown {
         name: PropertyName,
         //        value: Vec<Token>,
@@ -167,7 +170,7 @@ pub(crate) struct Declaration {
     pub important: Importance,
 }
 
-use super::{Selector, SelectorComponent, WhiteSpace};
+use super::{PseudoElement, Selector, SelectorComponent, WhiteSpace};
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct RuleSet {
@@ -485,6 +488,13 @@ pub(crate) fn parse_declaration(text: &str) -> IResult<&str, Option<Declaration>
                 Decl::Unknown { name: prop }
             }
         }
+        "content" => {
+            if let Ok(value) = parse_content(&value) {
+                Decl::Content { text: value }
+            } else {
+                Decl::Unknown { name: prop }
+            }
+        }
         _ => Decl::Unknown {
             name: prop,
             //            value: /*value*/"".into(),
@@ -768,6 +778,19 @@ fn parse_white_space(
     Ok(WhiteSpace::Normal)
 }
 
+// Parse content - currently only support a single string.
+fn parse_content(value: &RawValue) -> Result<String, nom::Err<nom::error::Error<&'static str>>> {
+    let mut result = String::new();
+    for tok in &value.tokens {
+        if let Token::String(word) = tok {
+            result.push_str(word);
+        } else {
+            return Err(empty_fail());
+        }
+    }
+    Ok(result)
+}
+
 pub(crate) fn parse_rules(text: &str) -> IResult<&str, Vec<Declaration>> {
     separated_list0(
         tuple((tag(";"), skip_optional_whitespace)),
@@ -856,6 +879,7 @@ fn parse_nth_child_args(text: &str) -> IResult<&str, SelectorComponent> {
 
     let sel = Selector {
         components: vec![SelectorComponent::Star],
+        ..Default::default()
     };
     Ok((rest, SelectorComponent::NthChild { a, b, sel }))
 }
@@ -913,6 +937,12 @@ fn parse_selector_without_element(text: &str) -> IResult<&str, Vec<SelectorCompo
     many1(parse_simple_selector_component)(text)
 }
 
+pub(crate) fn parse_pseudo_element(text: &str) -> IResult<&str, Option<PseudoElement>> {
+    opt(alt((
+        map(tag("::before"), |_| PseudoElement::Before),
+        map(tag("::after"), |_| PseudoElement::After))))(text)
+}
+
 pub(crate) fn parse_selector(text: &str) -> IResult<&str, Selector> {
     let (rest, mut components) = alt((
         parse_selector_with_element,
@@ -928,7 +958,9 @@ pub(crate) fn parse_selector(text: &str) -> IResult<&str, Selector> {
     if let Some(&SelectorComponent::CombDescendant) = components.last() {
         components.pop();
     }
-    Ok((rest, Selector { components }))
+
+    let (rest, pseudo_element) = parse_pseudo_element(rest)?;
+    Ok((rest, Selector { components, pseudo_element }))
 }
 
 fn parse_ruleset(text: &str) -> IResult<&str, RuleSet> {
@@ -1043,8 +1075,7 @@ pub(crate) fn parse_stylesheet(text: &str) -> IResult<&str, Vec<RuleSet>> {
 #[cfg(test)]
 mod test {
     use crate::css::{
-        parser::{Height, Importance, LengthUnit, RuleSet, Selector},
-        SelectorComponent,
+        parser::{Height, Importance, LengthUnit, RuleSet, Selector}, PseudoElement, SelectorComponent
     };
 
     use super::{Colour, Decl, Declaration, Overflow, PropertyName};
@@ -1170,6 +1201,7 @@ mod test {
                 vec![RuleSet {
                     selectors: vec![Selector {
                         components: vec![SelectorComponent::Element("foo".into()),],
+                        ..Default::default()
                     },],
                     declarations: vec![Declaration {
                         data: Decl::Color {
@@ -1198,6 +1230,7 @@ mod test {
                 vec![RuleSet {
                     selectors: vec![Selector {
                         components: vec![SelectorComponent::Class("foo".into()),],
+                        ..Default::default()
                     },],
                     declarations: vec![
                         Declaration {
@@ -1248,6 +1281,7 @@ mod test {
                 vec![RuleSet {
                     selectors: vec![Selector {
                         components: vec![SelectorComponent::Class("foo".into()),],
+                        ..Default::default()
                     },],
                     declarations: vec![
                         Declaration {
@@ -1321,6 +1355,7 @@ mod test {
                                 SelectorComponent::CombDescendant,
                                 SelectorComponent::Class("foo".into()),
                             ],
+                            ..Default::default()
                         },],
                         declarations: vec![Declaration {
                             data: Decl::Unknown {
@@ -1339,6 +1374,7 @@ mod test {
                                 SelectorComponent::CombDescendant,
                                 SelectorComponent::Class("foo".into()),
                             ],
+                            ..Default::default()
                         },],
                         declarations: vec![Declaration {
                             data: Decl::Color {
@@ -1347,6 +1383,126 @@ mod test {
                             important: Importance::Default,
                         },],
                     }
+                ]
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_comma_selector() {
+        assert_eq!(
+            super::parse_stylesheet(
+                "
+.foo a, p  { color: #112233; }
+            "
+            ),
+            Ok((
+                "",
+                vec![
+                    RuleSet {
+                        selectors: vec![
+                            Selector {
+                                components: vec![
+                                    SelectorComponent::Element("a".into()),
+                                    SelectorComponent::CombDescendant,
+                                    SelectorComponent::Class("foo".into()),
+                                ],
+                                ..Default::default()
+                            },
+                            Selector {
+                                components: vec![
+                                    SelectorComponent::Element("p".into()),
+                                ],
+                                ..Default::default()
+                            },
+                        ],
+                        declarations: vec![Declaration {
+                            data: Decl::Color {
+                                value: Colour::Rgb(0x11, 0x22, 0x33)
+                            },
+                            important: Importance::Default,
+                        },],
+                    },
+                ]
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_before_after() {
+        assert_eq!(
+            super::parse_stylesheet(
+                "
+.foo a::before, p::after  { color: #112233; }
+            "
+            ),
+            Ok((
+                "",
+                vec![
+                    RuleSet {
+                        selectors: vec![
+                            Selector {
+                                components: vec![
+                                    SelectorComponent::Element("a".into()),
+                                    SelectorComponent::CombDescendant,
+                                    SelectorComponent::Class("foo".into()),
+                                ],
+                                pseudo_element: Some(PseudoElement::Before),
+                            },
+                            Selector {
+                                components: vec![
+                                    SelectorComponent::Element("p".into()),
+                                ],
+                                pseudo_element: Some(PseudoElement::After),
+                            },
+                        ],
+                        declarations: vec![Declaration {
+                            data: Decl::Color {
+                                value: Colour::Rgb(0x11, 0x22, 0x33)
+                            },
+                            important: Importance::Default,
+                        },],
+                    },
+                ]
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_content() {
+        assert_eq!(
+            super::parse_stylesheet(
+                r#"
+.foo a::before, p::after  { content: "blah*#"; }
+            "#
+            ),
+            Ok((
+                "",
+                vec![
+                    RuleSet {
+                        selectors: vec![
+                            Selector {
+                                components: vec![
+                                    SelectorComponent::Element("a".into()),
+                                    SelectorComponent::CombDescendant,
+                                    SelectorComponent::Class("foo".into()),
+                                ],
+                                pseudo_element: Some(PseudoElement::Before),
+                            },
+                            Selector {
+                                components: vec![
+                                    SelectorComponent::Element("p".into()),
+                                ],
+                                pseudo_element: Some(PseudoElement::After),
+                            },
+                        ],
+                        declarations: vec![Declaration {
+                            data: Decl::Content {
+                                text: "blah*#".into()
+                            },
+                            important: Importance::Default,
+                        },],
+                    },
                 ]
             ))
         );
@@ -1405,7 +1561,8 @@ mod test {
                         a: 2,
                         b: 0,
                         sel: sel_all.clone()
-                    }]
+                    }],
+                    ..Default::default()
                 }
             )
         );
@@ -1418,7 +1575,8 @@ mod test {
                         a: 2,
                         b: 1,
                         sel: sel_all.clone()
-                    }]
+                    }],
+                    ..Default::default()
                 }
             )
         );
@@ -1431,7 +1589,8 @@ mod test {
                         a: 0,
                         b: 17,
                         sel: sel_all.clone()
-                    }]
+                    }],
+                    ..Default::default()
                 }
             )
         );
@@ -1444,7 +1603,8 @@ mod test {
                         a: 17,
                         b: 0,
                         sel: sel_all.clone()
-                    }]
+                    }],
+                    ..Default::default()
                 }
             )
         );
@@ -1457,7 +1617,8 @@ mod test {
                         a: 10,
                         b: -1,
                         sel: sel_all.clone()
-                    }]
+                    }],
+                    ..Default::default()
                 }
             )
         );
@@ -1470,7 +1631,8 @@ mod test {
                         a: 10,
                         b: 9,
                         sel: sel_all.clone()
-                    }]
+                    }],
+                    ..Default::default()
                 }
             )
         );
@@ -1483,7 +1645,8 @@ mod test {
                         a: -1,
                         b: 3,
                         sel: sel_all.clone()
-                    }]
+                    }],
+                    ..Default::default()
                 }
             )
         );
@@ -1496,7 +1659,8 @@ mod test {
                         a: 1,
                         b: 0,
                         sel: sel_all.clone()
-                    }]
+                    }],
+                    ..Default::default()
                 }
             )
         );
@@ -1509,7 +1673,8 @@ mod test {
                         a: 1,
                         b: 0,
                         sel: sel_all.clone()
-                    }]
+                    }],
+                    ..Default::default()
                 }
             )
         );
@@ -1522,7 +1687,8 @@ mod test {
                         a: -1,
                         b: 0,
                         sel: sel_all.clone()
-                    }]
+                    }],
+                    ..Default::default()
                 }
             )
         );

--- a/src/css/types.rs
+++ b/src/css/types.rs
@@ -1,0 +1,5 @@
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub(crate) enum Importance {
+    Default,
+    Important,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2381,7 +2381,8 @@ pub mod config {
     use std::io;
 
     use super::Error;
-    use crate::css::StyleData;
+    use crate::css::types::Importance;
+    use crate::css::{Ruleset, Selector, SelectorComponent, Style, StyleData};
     use crate::{
         css::{PseudoContent, PseudoElement, StyleDecl},
         render::text_renderer::{
@@ -2599,70 +2600,38 @@ pub mod config {
             self.wrap_links = false;
             self
         }
+
+        /// Make a simple "contains" type rule for an element.
+        fn make_surround_rule(element: &str, after: bool, content: &str) -> Ruleset {
+            Ruleset {
+                selector: Selector {
+                    components: vec![SelectorComponent::Element(element.into())],
+                    pseudo_element: Some(if after {
+                        PseudoElement::After
+                    } else {
+                        PseudoElement::Before
+                    }),
+                },
+                styles: vec![StyleDecl {
+                    style: Style::Content(PseudoContent {
+                        text: content.into(),
+                    }),
+                    importance: Importance::Default,
+                }],
+            }
+        }
+
         /// Decorate <em> etc. similarly to markdown
         pub fn do_decorate(mut self) -> Self {
-            use crate::css::{types::Importance, Ruleset, Selector, SelectorComponent, Style};
             self.style.add_agent_rules(&[
-                Ruleset {
-                    selector: Selector {
-                        components: vec![SelectorComponent::Element("em".into())],
-                        pseudo_element: Some(PseudoElement::Before),
-                    },
-                    styles: vec![StyleDecl {
-                        style: Style::Content(PseudoContent { text: "*".into() }),
-                        importance: Importance::Default,
-                    }],
-                },
-                Ruleset {
-                    selector: Selector {
-                        components: vec![SelectorComponent::Element("em".into())],
-                        pseudo_element: Some(PseudoElement::After),
-                    },
-                    styles: vec![StyleDecl {
-                        style: Style::Content(PseudoContent { text: "*".into() }),
-                        importance: Importance::Default,
-                    }],
-                },
-                Ruleset {
-                    selector: Selector {
-                        components: vec![SelectorComponent::Element("dt".into())],
-                        pseudo_element: Some(PseudoElement::Before),
-                    },
-                    styles: vec![StyleDecl {
-                        style: Style::Content(PseudoContent { text: "*".into() }),
-                        importance: Importance::Default,
-                    }],
-                },
-                Ruleset {
-                    selector: Selector {
-                        components: vec![SelectorComponent::Element("dt".into())],
-                        pseudo_element: Some(PseudoElement::After),
-                    },
-                    styles: vec![StyleDecl {
-                        style: Style::Content(PseudoContent { text: "*".into() }),
-                        importance: Importance::Default,
-                    }],
-                },
-                Ruleset {
-                    selector: Selector {
-                        components: vec![SelectorComponent::Element("strong".into())],
-                        pseudo_element: Some(PseudoElement::Before),
-                    },
-                    styles: vec![StyleDecl {
-                        style: Style::Content(PseudoContent { text: "**".into() }),
-                        importance: Importance::Default,
-                    }],
-                },
-                Ruleset {
-                    selector: Selector {
-                        components: vec![SelectorComponent::Element("strong".into())],
-                        pseudo_element: Some(PseudoElement::After),
-                    },
-                    styles: vec![StyleDecl {
-                        style: Style::Content(PseudoContent { text: "**".into() }),
-                        importance: Importance::Default,
-                    }],
-                },
+                Self::make_surround_rule("em", false, "*"),
+                Self::make_surround_rule("em", true, "*"),
+                Self::make_surround_rule("dt", false, "*"),
+                Self::make_surround_rule("dt", true, "*"),
+                Self::make_surround_rule("strong", false, "**"),
+                Self::make_surround_rule("strong", true, "**"),
+                Self::make_surround_rule("code", false, "`"),
+                Self::make_surround_rule("code", true, "`"),
             ]);
             self
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2682,14 +2682,14 @@ pub mod config {
         with_decorator(RichDecorator::new())
     }
 
-    /// Return a Config initialized with a `RichDecorator` and decoration disabled.
-    pub fn rich_no_decorate() -> Config<RichDecorator> {
-        with_decorator(RichDecorator::new_undecorated())
-    }
-
     /// Return a Config initialized with a `PlainDecorator`.
     pub fn plain() -> Config<PlainDecorator> {
         with_decorator(PlainDecorator::new()).do_decorate()
+    }
+
+    /// Return a Config initialized with a `PlainDecorator`.
+    pub fn plain_no_decorate() -> Config<PlainDecorator> {
+        with_decorator(PlainDecorator::new())
     }
 
     /// Return a Config initialized with a custom decorator.

--- a/src/render/text_renderer.rs
+++ b/src/render/text_renderer.rs
@@ -1892,10 +1892,7 @@ impl TextDecorator for TrivialDecorator {
 /// A decorator to generate rich text (styled) rather than
 /// pure text output.
 #[derive(Clone, Debug)]
-pub struct RichDecorator {
-    // Don't output decorations around '*bold*' text.
-    skip_decorations: bool,
-}
+pub struct RichDecorator {}
 
 /// Annotation type for "rich" text.  Text is associated with a set of
 /// these.
@@ -1929,17 +1926,7 @@ impl RichDecorator {
     /// Create a new `RichDecorator` with the default settings.
     #[allow(clippy::new_without_default)]
     pub fn new() -> RichDecorator {
-        RichDecorator {
-            skip_decorations: false,
-        }
-    }
-
-    /// Create a new `RichDecorator` which doesn't add decorations
-    /// when terminal formatting can be used.
-    pub fn new_undecorated() -> RichDecorator {
-        RichDecorator {
-            skip_decorations: true,
-        }
+        RichDecorator {}
     }
 }
 
@@ -1963,19 +1950,11 @@ impl TextDecorator for RichDecorator {
     }
 
     fn decorate_strong_start(&self) -> (String, Self::Annotation) {
-        if self.skip_decorations {
-            ("".to_string(), RichAnnotation::Strong)
-        } else {
-            ("*".to_string(), RichAnnotation::Strong)
-        }
+        ("".to_string(), RichAnnotation::Strong)
     }
 
     fn decorate_strong_end(&self) -> String {
-        if self.skip_decorations {
-            "".to_string()
-        } else {
-            "*".to_string()
-        }
+        "".to_string()
     }
 
     fn decorate_strikeout_start(&self) -> (String, Self::Annotation) {
@@ -1987,19 +1966,11 @@ impl TextDecorator for RichDecorator {
     }
 
     fn decorate_code_start(&self) -> (String, Self::Annotation) {
-        if self.skip_decorations {
-            ("".to_string(), RichAnnotation::Code)
-        } else {
-            ("`".to_string(), RichAnnotation::Code)
-        }
+        ("".to_string(), RichAnnotation::Code)
     }
 
     fn decorate_code_end(&self) -> String {
-        if self.skip_decorations {
-            "".to_string()
-        } else {
-            "`".to_string()
-        }
+        "".to_string()
     }
 
     fn decorate_preformat_first(&self) -> Self::Annotation {

--- a/src/render/text_renderer.rs
+++ b/src/render/text_renderer.rs
@@ -1733,19 +1733,19 @@ impl TextDecorator for PlainDecorator {
     }
 
     fn decorate_em_start(&self) -> (String, Self::Annotation) {
-        ("*".to_string(), ())
+        ("".to_string(), ())
     }
 
     fn decorate_em_end(&self) -> String {
-        "*".to_string()
+        "".to_string()
     }
 
     fn decorate_strong_start(&self) -> (String, Self::Annotation) {
-        ("**".to_string(), ())
+        ("".to_string(), ())
     }
 
     fn decorate_strong_end(&self) -> String {
-        "**".to_string()
+        "".to_string()
     }
 
     fn decorate_strikeout_start(&self) -> (String, Self::Annotation) {
@@ -1757,11 +1757,11 @@ impl TextDecorator for PlainDecorator {
     }
 
     fn decorate_code_start(&self) -> (String, Self::Annotation) {
-        ("`".to_string(), ())
+        ("".to_string(), ())
     }
 
     fn decorate_code_end(&self) -> String {
-        "`".to_string()
+        "".to_string()
     }
 
     fn decorate_preformat_first(&self) -> Self::Annotation {}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2820,4 +2820,22 @@ at  line  breaks
             20,
         );
     }
+
+    #[test]
+    fn test_before_after() {
+        test_html_coloured(br#"
+        <style>
+          span.bracketed::before {
+              content: "[";
+          }
+          span.bracketed::after {
+              content: "]";
+          }
+        </style>
+        <body>
+        <p>Hello <span class="bracketed">world</span>!</p>
+        </body>"#,
+        r#"Hello [world]!
+"#, 80);
+    }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2823,7 +2823,8 @@ at  line  breaks
 
     #[test]
     fn test_before_after() {
-        test_html_coloured(br#"
+        test_html_coloured(
+            br#"
         <style>
           span.bracketed::before {
               content: "[";
@@ -2835,7 +2836,9 @@ at  line  breaks
         <body>
         <p>Hello <span class="bracketed">world</span>!</p>
         </body>"#,
-        r#"Hello [world]!
-"#, 80);
+            r#"Hello [world]!
+"#,
+            80,
+        );
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1435,14 +1435,14 @@ fn test_read_rich() {
         .render_to_lines(parse(html).unwrap(), 80)
         .unwrap();
     let tag = vec![RichAnnotation::Strong];
-    let line = TaggedLine::from_string("*bold*".to_owned(), &tag);
+    let line = TaggedLine::from_string("bold".to_owned(), &tag);
     assert_eq!(vec![line], lines);
 }
 
 #[test]
 fn test_read_rich_nodecorate() {
     let html: &[u8] = b"<strong>bold</strong>";
-    let lines = config::rich_no_decorate()
+    let lines = config::rich()
         .render_to_lines(parse(html).unwrap(), 80)
         .unwrap();
     let tag = vec![RichAnnotation::Strong];


### PR DESCRIPTION
Instead of using the decorator to add decorations around `<em>` and similar tags, we internally now use CSS features instead - this means it can be enabled or not independent of the decorator.

* Add new `config::plain_no_decorate()`, which leaves off the decoration around `*bold*` text etc.
* `config::plain()` is equivalent to `config::plain_no_decorate().do_decorate()`
* The `RichDecorator` no longer adds these decorations by default, but `config::rich().do_decorate()` is available.
* With the `css` feature enabled, `::before` and `::after` pseudo-elements are supported along with the `content: "foo"` style, which is used to implement the above.  This can be used to tweak the decoration with, for example, `add_agent_css()`.