### PR TITLE
Support `h5` and `h6` tags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1635,7 +1635,9 @@ fn process_dom_node<T: Write>(
                 expanded_name!(html "h1")
                 | expanded_name!(html "h2")
                 | expanded_name!(html "h3")
-                | expanded_name!(html "h4") => {
+                | expanded_name!(html "h4")
+                | expanded_name!(html "h5")
+                | expanded_name!(html "h6") => {
                     let level: usize = name.local[1..].parse().unwrap();
                     pending(input, move |_, cs| {
                         Some(RenderNode::new_styled(Header(level, cs), computed))


### PR DESCRIPTION
Thanks so much for this effort that is a great fit for my `HTML -> plaintext` and `HTML -> Markdown` use cases! 🥳 

This is a simple change that adds support for the HTML `h5` and `h6` tags to complement the existing parsing of `h1`, `h2`, `h3`, and `h4`.