### PR TITLE
Add support for external syntax highlighting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,13 @@ Possible log types:
 
 ### Latest
 
+### 0.15.0
+
 - [added] Syntax highlighting support for `<pre>` blocks
   (`Config::register_highlighter` and CSS `x-syntax: foo`)
-- [changed] CSS extensions are now only available in agent and user CSS.
+- [changed] CSS extensions (until now `display: x-raw-dom`, and only if the
+  `css_ext` Cargo feature is enabled) are now only available in agent and user CSS.
+  This is a breaking change, but is not likely to affect many users.
 
 ### 0.14.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Possible log types:
 
 ### Latest
 
+- [added] Syntax highlighting support for `<pre>` blocks
+  (`Config::register_highlighter` and CSS `x-syntax: foo`)
+- [changed] CSS extensions are now only available in agent and user CSS.
+
 ### 0.14.4
 
 - [added] `RcDom::serialize`, and expose a few more of the `RcDom` types.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,7 +238,7 @@ checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "html2text"
-version = "0.14.4"
+version = "0.15.0"
 dependencies = [
  "argparse",
  "backtrace",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,10 +104,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
+name = "cc"
+version = "1.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -120,6 +150,24 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "deranged"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "env_filter"
@@ -145,6 +193,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "flate2"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,6 +231,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "hashbrown"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+
+[[package]]
 name = "html2text"
 version = "0.14.4"
 dependencies = [
@@ -170,9 +246,10 @@ dependencies = [
  "html5ever",
  "log",
  "nom",
+ "syntect",
  "tendril",
  "termion",
- "thiserror",
+ "thiserror 2.0.12",
  "unicode-width",
 ]
 
@@ -189,10 +266,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
@@ -230,10 +323,16 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "libc",
  "redox_syscall",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "lock_api"
@@ -320,6 +419,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "numtoa"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,6 +444,28 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "onig"
+version = "6.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c4b31c8722ad9171c6d77d3557db078cab2bd50afcc9d09c8b315c59df8ca4f"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "parking_lot"
@@ -402,6 +529,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plist"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac26e981c03a6e53e0aee43c113e3202f5581d5360dae7bd2c70e800dd0451d"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +563,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +581,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -461,7 +622,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -506,6 +667,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,6 +706,24 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "siphasher"
@@ -580,6 +774,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntect"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874dcfa363995604333cf947ae9f751ca3af4522c60886774c4963943b4746b1"
+dependencies = [
+ "bincode",
+ "bitflags 1.3.2",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "onig",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror 1.0.69",
+ "walkdir",
+ "yaml-rust",
+]
+
+[[package]]
 name = "tendril"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,11 +820,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.12",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -620,6 +856,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "time-macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -645,6 +912,25 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "windows-sys"
@@ -718,3 +1004,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ path = "examples/html2text.rs"
 env_logger = "0.11.6"
 argparse = "0.2.2"
 log = "0.4.20"
+syntect = "5.2.0"
 
 [target.'cfg(unix)'.dev-dependencies]
 termion = "4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "html2text"
-version = "0.14.4"
+version = "0.15.0"
 authors = ["Chris Emerson <github@mail.nosreme.org>"]
 description = "Render HTML as plain text."
 repository = "https://github.com/jugglerchris/rust-html2text/"

--- a/examples/html2text.rs
+++ b/examples/html2text.rs
@@ -140,8 +140,9 @@ fn update_config<T: TextDecorator>(mut config: Config<T>, flags: &Flags) -> Conf
     }
     #[cfg(feature = "css_ext")]
     if flags.syntax_highlight {
-        config =
-            config.register_highlighter("rs", Box::new(|text| do_syntect_highlight(text, "rs")));
+        config = config
+            .register_highlighter("rs", Box::new(|text| do_syntect_highlight(text, "rs")))
+            .register_highlighter("html", Box::new(|text| do_syntect_highlight(text, "html")));
     }
     match (flags.link_footnotes, flags.no_link_footnotes) {
         (true, true) => {

--- a/src/css.rs
+++ b/src/css.rs
@@ -223,6 +223,13 @@ pub(crate) struct PseudoContent {
     pub(crate) text: String,
 }
 
+#[cfg(feature = "css_ext")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SyntaxInfo {
+    /// Highlight language
+    pub(crate) language: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum Style {
     #[cfg(feature = "css")]
@@ -234,6 +241,8 @@ pub(crate) enum Style {
     #[cfg(feature = "css")]
     WhiteSpace(WhiteSpace),
     Content(PseudoContent),
+    #[cfg(feature = "css_ext")]
+    Syntax(SyntaxInfo),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -260,6 +269,8 @@ impl std::fmt::Display for StyleDecl {
                 WhiteSpace::PreWrap => write!(f, "white-space: pre-wrap")?,
             },
             Style::Content(content) => write!(f, "content: \"{}\"", content.text)?,
+            #[cfg(feature = "css_ext")]
+            Style::Syntax(syntax_info) => write!(f, "x-syntax: {}", syntax_info.language)?,
         }
         match self.importance {
             Importance::Default => (),
@@ -295,7 +306,8 @@ pub(crate) struct StyleData {
 }
 
 #[cfg(feature = "css")]
-fn styles_from_properties(decls: &[parser::Declaration]) -> Vec<StyleDecl> {
+fn styles_from_properties(decls: &[parser::Declaration],
+    _allow_extensions: bool) -> Vec<StyleDecl> {
     let mut styles = Vec::new();
     html_trace_quiet!("styles:from_properties2: {decls:?}");
     let mut overflow_hidden = false;
@@ -362,6 +374,9 @@ fn styles_from_properties(decls: &[parser::Declaration]) -> Vec<StyleDecl> {
                 }
                 #[cfg(feature = "css_ext")]
                 parser::Display::RawDom => {
+                    if !_allow_extensions {
+                        continue;
+                    }
                     styles.push(StyleDecl {
                         style: Style::Display(Display::ExtRawDom),
                         importance: decl.important,
@@ -378,6 +393,18 @@ fn styles_from_properties(decls: &[parser::Declaration]) -> Vec<StyleDecl> {
             parser::Decl::Content { text } => {
                 styles.push(StyleDecl {
                     style: Style::Content(PseudoContent { text: text.clone() }),
+                    importance: decl.important,
+                });
+            }
+            #[cfg(feature = "css_ext")]
+            parser::Decl::XSyntax { language } => {
+                if !_allow_extensions {
+                    continue;
+                }
+                styles.push(StyleDecl {
+                    style: Style::Syntax(SyntaxInfo {
+                        language: language.clone(),
+                    }),
                     importance: decl.important,
                 });
             } /*
@@ -401,11 +428,11 @@ impl StyleData {
     #[cfg(feature = "css")]
     /// Add some CSS source to be included.  The source will be parsed
     /// and the relevant and supported features extracted.
-    fn do_add_css(css: &str, rules: &mut Vec<Ruleset>) -> Result<()> {
+    fn do_add_css(css: &str, rules: &mut Vec<Ruleset>, allow_extensions: bool) -> Result<()> {
         let (_, ss) = parser::parse_stylesheet(css).map_err(|_| crate::Error::CssParseError)?;
 
         for rule in ss {
-            let styles = styles_from_properties(&rule.declarations);
+            let styles = styles_from_properties(&rule.declarations, allow_extensions);
             if !styles.is_empty() {
                 for selector in rule.selectors {
                     let ruleset = Ruleset {
@@ -429,19 +456,19 @@ impl StyleData {
     #[cfg(feature = "css")]
     /// Add some CSS source to be included as part of the user agent ("browser") CSS rules.
     pub fn add_agent_css(&mut self, css: &str) -> Result<()> {
-        Self::do_add_css(css, &mut self.agent_rules)
+        Self::do_add_css(css, &mut self.agent_rules, true)
     }
 
     #[cfg(feature = "css")]
     /// Add some CSS source to be included as part of the user CSS rules.
     pub fn add_user_css(&mut self, css: &str) -> Result<()> {
-        Self::do_add_css(css, &mut self.user_rules)
+        Self::do_add_css(css, &mut self.user_rules, true)
     }
 
     #[cfg(feature = "css")]
     /// Add some CSS source to be included as part of the document/author CSS rules.
     pub fn add_author_css(&mut self, css: &str) -> Result<()> {
-        Self::do_add_css(css, &mut self.author_rules)
+        Self::do_add_css(css, &mut self.author_rules, false)
     }
 
     #[cfg(feature = "css")]
@@ -593,6 +620,15 @@ impl StyleData {
                 result_target
                     .content
                     .maybe_update(important, origin, specificity, content.clone());
+            }
+            #[cfg(feature = "css_ext")]
+            Style::Syntax(ref syntax_info) => {
+                result_target.syntax.maybe_update(
+                    important,
+                    origin,
+                    specificity,
+                    syntax_info.clone(),
+                );
             }
         }
     }

--- a/src/css.rs
+++ b/src/css.rs
@@ -306,8 +306,10 @@ pub(crate) struct StyleData {
 }
 
 #[cfg(feature = "css")]
-fn styles_from_properties(decls: &[parser::Declaration],
-    _allow_extensions: bool) -> Vec<StyleDecl> {
+fn styles_from_properties(
+    decls: &[parser::Declaration],
+    _allow_extensions: bool,
+) -> Vec<StyleDecl> {
     let mut styles = Vec::new();
     html_trace_quiet!("styles:from_properties2: {decls:?}");
     let mut overflow_hidden = false;


### PR DESCRIPTION
Allow for syntax highlighting `<pre>` blocks (with "css_ext" feature)

Add `Config::register_highlighter()`, which can add a
syntax highlighting function associated with a language name. This can
be used with a CSS declaration `x-syntax: name`.  The highlighter
is passed a raw string containing all the text inside the `<pre>`, not
including any elements, and returns a list of styled spans.  Foreground
and background colours are currently supported.

The CSS extensions are no longer available in document/author CSS, since
we're likely to want to view untrusted HTML.  In an application which
wants to give HTML the ability to do so, it can be done via a class and
an extra agent rule referring to that class.

Add `--syntax` option to the html2text example to register a `rs` (rust)
highlighter as an example, which can be used with `--agent-css='pre.rust
{ x-syntax: rs; }` (`--agent-css` is also new).  This also acts as an example 
using syntect.

Fixes #36.
