### PR TITLE
Implement attribute selectors, and improve block padding.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Possible log types:
 
 ### Latest
 
+- [added] CSS: Support basic attribute selectors (`div[attr="bar"]`).
+- [changed] Syntax highlighting uses the priority of the `x-syntax` rule.
+- [fixed] With `pad_block_width` enabled, do a better job of padding blocks.
+  In particular, the padding gets the block's background colour (when CSS etc.
+  are being used).
+
 ### 0.15.0
 
 - [added] Syntax highlighting support for `<pre>` blocks

--- a/examples/html2text.rs
+++ b/examples/html2text.rs
@@ -153,6 +153,9 @@ fn update_config<T: TextDecorator>(mut config: Config<T>, flags: &Flags) -> Conf
         (false, true) => config = config.link_footnotes(false),
         (false, false) => {}
     };
+    if flags.pad_width {
+        config = config.pad_block_width();
+    }
     config
 }
 
@@ -227,6 +230,7 @@ struct Flags {
     show_render: bool,
     #[cfg(feature = "css")]
     show_css: bool,
+    pad_width: bool,
     link_footnotes: bool,
     no_link_footnotes: bool,
     #[cfg(feature = "css_ext")]
@@ -257,6 +261,7 @@ fn main() {
         show_css: false,
         #[cfg(feature = "css")]
         agent_css: Default::default(),
+        pad_width: false,
         link_footnotes: false,
         no_link_footnotes: false,
         #[cfg(feature = "css_ext")]
@@ -290,6 +295,11 @@ fn main() {
             &["-L", "--literal"],
             StoreTrue,
             "Output only literal text (no decorations)",
+        );
+        ap.refer(&mut flags.pad_width).add_option(
+            &["--pad-width"],
+            StoreTrue,
+            "Pad blocks to their full width",
         );
         ap.refer(&mut flags.link_footnotes).add_option(
             &["--link-footnotes"],

--- a/src/css.rs
+++ b/src/css.rs
@@ -27,7 +27,7 @@ pub(crate) enum AttrOperator {
     #[allow(unused)]
     Present, // foo[href]
     #[allow(unused)]
-    Equal,   // foo[href="foo"]
+    Equal, // foo[href="foo"]
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -51,7 +51,7 @@ pub(crate) enum SelectorComponent {
         op: AttrOperator,
         // TODO: other comparisions like $=
         // TODO: case sensitivity flags
-    }
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -72,8 +72,14 @@ impl std::fmt::Display for SelectorComponent {
             SelectorComponent::NthChild { a, b, .. } => write!(f, ":nth-child({}n+{})", a, b),
             SelectorComponent::Attr { name, value, op } => match op {
                 AttrOperator::Present => write!(f, "[{name}]"),
-                AttrOperator::Equal => write!(f, "[{name} = \"{}\"]", value.as_ref().expect("Missing value for attribute equality comparison")),
-            }
+                AttrOperator::Equal => write!(
+                    f,
+                    "[{name} = \"{}\"]",
+                    value
+                        .as_ref()
+                        .expect("Missing value for attribute equality comparison")
+                ),
+            },
         }
     }
 }
@@ -124,7 +130,7 @@ impl Selector {
                         false
                     }
                 },
-                SelectorComponent::Attr{ name, value, op } => match &node.data {
+                SelectorComponent::Attr { name, value, op } => match &node.data {
                     Document
                     | NodeData::Doctype { .. }
                     | NodeData::Text { .. }
@@ -133,13 +139,17 @@ impl Selector {
                     Element { attrs, .. } => {
                         let attrs = attrs.borrow();
                         for attr in attrs.iter() {
-                            if &attr.name.local == name{
+                            if &attr.name.local == name {
                                 match op {
                                     AttrOperator::Present => {
                                         return Self::do_matches(&comps[1..], node);
                                     }
                                     AttrOperator::Equal => {
-                                        if &*attr.value == value.as_ref().expect("No value in Attr equality comparison") {
+                                        if &*attr.value
+                                            == value
+                                                .as_ref()
+                                                .expect("No value in Attr equality comparison")
+                                        {
                                             return Self::do_matches(&comps[1..], node);
                                         } else {
                                             return false;
@@ -353,8 +363,10 @@ pub(crate) struct StyleData {
 }
 
 #[cfg(feature = "css")]
-fn styles_from_properties(decls: &[parser::Declaration],
-    _allow_extensions: bool) -> Vec<StyleDecl> {
+fn styles_from_properties(
+    decls: &[parser::Declaration],
+    _allow_extensions: bool,
+) -> Vec<StyleDecl> {
     let mut styles = Vec::new();
     html_trace_quiet!("styles:from_properties2: {decls:?}");
     let mut overflow_hidden = false;

--- a/src/css.rs
+++ b/src/css.rs
@@ -24,7 +24,9 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// Attribute seletor operations
 pub(crate) enum AttrOperator {
+    #[allow(unused)]
     Present, // foo[href]
+    #[allow(unused)]
     Equal,   // foo[href="foo"]
 }
 

--- a/src/css/parser.rs
+++ b/src/css/parser.rs
@@ -698,10 +698,8 @@ fn parse_quoted_string(text: &str) -> IResult<&str, String> {
     let (rest, result) = parse_string_token(text)?;
 
     match result {
-        Token::String(s) => {
-            Ok((rest, s.to_string()))
-        }
-        _ => fail("Invalid string")
+        Token::String(s) => Ok((rest, s.to_string())),
+        _ => fail("Invalid string"),
     }
 }
 
@@ -841,23 +839,36 @@ fn parse_class(text: &str) -> IResult<&str, SelectorComponent> {
 
 fn parse_attr(text: &str) -> IResult<&str, SelectorComponent> {
     alt((
-        map(tuple((tag("["), parse_ident, tag("]"))), |(_, name, _)| SelectorComponent::Attr {
-            name,
-            value: None,
-            op: super::AttrOperator::Present
+        map(tuple((tag("["), parse_ident, tag("]"))), |(_, name, _)| {
+            SelectorComponent::Attr {
+                name,
+                value: None,
+                op: super::AttrOperator::Present,
+            }
         }),
-        map(tuple((tag("["), parse_ident, tag("="), parse_quoted_string, tag("]"))), |(_, name, _, value, _)| SelectorComponent::Attr {
-            name,
-            value: Some(value),
-            op: super::AttrOperator::Equal
-        }),
-        map(tuple((tag("["), parse_ident, tag("="), parse_ident, tag("]"))), |(_, name, _, value, _)| SelectorComponent::Attr {
-            name,
-            value: Some(value),
-            op: super::AttrOperator::Equal
-        }),
+        map(
+            tuple((
+                tag("["),
+                parse_ident,
+                tag("="),
+                parse_quoted_string,
+                tag("]"),
+            )),
+            |(_, name, _, value, _)| SelectorComponent::Attr {
+                name,
+                value: Some(value),
+                op: super::AttrOperator::Equal,
+            },
+        ),
+        map(
+            tuple((tag("["), parse_ident, tag("="), parse_ident, tag("]"))),
+            |(_, name, _, value, _)| SelectorComponent::Attr {
+                name,
+                value: Some(value),
+                op: super::AttrOperator::Equal,
+            },
+        ),
     ))(text)
-
 }
 
 #[derive(Eq, PartialEq, Copy, Clone)]
@@ -1148,7 +1159,7 @@ pub(crate) fn parse_style_attribute(text: &str) -> crate::Result<Vec<StyleDecl>>
 mod test {
     use crate::css::{
         parser::{Height, Importance, LengthUnit, RuleSet, Selector},
-        PseudoElement, SelectorComponent, AttrOperator,
+        AttrOperator, PseudoElement, SelectorComponent,
     };
 
     use super::{Colour, Decl, Declaration, Overflow, PropertyName};
@@ -1756,8 +1767,8 @@ mod test {
     }
     #[test]
     fn test_attr() {
-        use SelectorComponent::{Attr, Class, Element};
         use AttrOperator::*;
+        use SelectorComponent::{Attr, Class, Element};
         assert_eq!(
             super::parse_selector("[foo]").unwrap(),
             (

--- a/src/css/parser.rs
+++ b/src/css/parser.rs
@@ -1806,13 +1806,13 @@ mod test {
                 "",
                 Selector {
                     components: vec![
-                        Element("x".into()),
-                        Class("y".into()),
                         Attr {
                             name: "foo".into(),
                             value: Some("some string".into()),
                             op: Equal,
-                        }
+                        },
+                        Class("y".into()),
+                        Element("x".into()),
                     ],
                     ..Default::default()
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1387,6 +1387,11 @@ impl HtmlContext {
         };
         let highlighted = highlighter(&text);
 
+        let origin = computed.syntax.origin;
+        let spec = computed.syntax.specificity;
+        let important = computed.syntax.important;
+
+
         let mut computed = computed.inherit();
         computed.white_space.maybe_update(
             false,
@@ -1400,16 +1405,16 @@ impl HtmlContext {
         for (style, s) in highlighted {
             let mut cstyle = computed.inherit();
             cstyle.colour.maybe_update(
-                true,
-                StyleOrigin::Author,
-                Specificity::inline(),
+                important,
+                origin,
+                spec,
                 style.fg_colour,
             );
             if let Some(bgcol) = style.bg_colour {
                 cstyle.bg_colour.maybe_update(
-                    true,
-                    StyleOrigin::Author,
-                    Specificity::inline(),
+                    important,
+                    origin,
+                    spec,
                     bgcol,
                 );
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1391,7 +1391,6 @@ impl HtmlContext {
         let spec = computed.syntax.specificity;
         let important = computed.syntax.important;
 
-
         let mut computed = computed.inherit();
         computed.white_space.maybe_update(
             false,
@@ -1404,19 +1403,13 @@ impl HtmlContext {
         let mut children = Vec::new();
         for (style, s) in highlighted {
             let mut cstyle = computed.inherit();
-            cstyle.colour.maybe_update(
-                important,
-                origin,
-                spec,
-                style.fg_colour,
-            );
+            cstyle
+                .colour
+                .maybe_update(important, origin, spec, style.fg_colour);
             if let Some(bgcol) = style.bg_colour {
-                cstyle.bg_colour.maybe_update(
-                    important,
-                    origin,
-                    spec,
-                    bgcol,
-                );
+                cstyle
+                    .bg_colour
+                    .maybe_update(important, origin, spec, bgcol);
             }
             children.push(RenderNode::new_styled(
                 RenderNodeInfo::Text(s.into()),

--- a/src/render/text_renderer.rs
+++ b/src/render/text_renderer.rs
@@ -355,7 +355,12 @@ struct WrappedBlock<T> {
 }
 
 impl<T: Clone + Eq + Debug + Default> WrappedBlock<T> {
-    pub fn new(width: usize, pad_blocks: bool, allow_overflow: bool, default_tag: T) -> WrappedBlock<T> {
+    pub fn new(
+        width: usize,
+        pad_blocks: bool,
+        allow_overflow: bool,
+        default_tag: T,
+    ) -> WrappedBlock<T> {
         WrappedBlock {
             width,
             text: Vec::new(),
@@ -367,7 +372,7 @@ impl<T: Clone + Eq + Debug + Default> WrappedBlock<T> {
             pre_wrapped: false,
             pad_blocks,
             allow_overflow,
-            default_tag
+            default_tag,
         }
     }
 
@@ -1167,7 +1172,7 @@ impl<D: TextDecorator> SubRenderer<D> {
                 RenderLine::Text(ref mut tl) => {
                     tl.pad_to(self.width, &self.ann_stack);
                 }
-                RenderLine::Line(..) => ()
+                RenderLine::Line(..) => (),
             }
         }
         self.lines.push_back(line);
@@ -1419,7 +1424,12 @@ impl<D: TextDecorator> Renderer for SubRenderer<D> {
         }
         let filtered_text = s.as_deref().unwrap_or(text);
         let ws_mode = self.ws_mode();
-        let wrapping = get_wrapping_or_insert::<D>(&mut self.wrapping, &self.options, self.width, &self.ann_stack);
+        let wrapping = get_wrapping_or_insert::<D>(
+            &mut self.wrapping,
+            &self.options,
+            self.width,
+            &self.ann_stack,
+        );
         let mut pre_tag_start;
         let mut pre_tag_cont;
 
@@ -1763,8 +1773,13 @@ impl<D: TextDecorator> Renderer for SubRenderer<D> {
     fn record_frag_start(&mut self, fragname: &str) {
         use self::TaggedLineElement::FragmentStart;
 
-        get_wrapping_or_insert::<D>(&mut self.wrapping, &self.options, self.width, &self.ann_stack)
-            .add_element(FragmentStart(fragname.to_string()));
+        get_wrapping_or_insert::<D>(
+            &mut self.wrapping,
+            &self.options,
+            self.width,
+            &self.ann_stack,
+        )
+        .add_element(FragmentStart(fragname.to_string()));
     }
 
     #[allow(unused)]


### PR DESCRIPTION
CSS: Support basic attribute selectors (`div[attr="bar"]`).                            

Syntax highlighting uses the priority of the `x-syntax` rule.                        

With `pad_block_width` enabled, do a better job of padding blocks.   In particular, the padding gets the block's background colour (when CSS etc. are being used). 