### PR TITLE
Improvements to syntax highlighting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,12 +67,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys",
 ]
 
@@ -90,9 +90,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -126,15 +126,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "cc"
-version = "1.2.21"
+version = "1.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
+checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
 dependencies = [
  "shlex",
 ]
@@ -289,9 +289,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.6"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f33145a5cbea837164362c7bd596106eb7c5198f97d1ba6f6ebb3223952e488"
+checksum = "a194df1107f33c79f4f93d02c80798520551949d59dfad22b6157048a88cca93"
 dependencies = [
  "jiff-static",
  "log",
@@ -302,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.6"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ce13c40ec6956157a3635d97a1ee2df323b263f09ea14165131289cb0f5c19"
+checksum = "6c6e1db7ed32c6c71b759497fae34bf7933636f75a251b9e736555da426f6442"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -313,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libredox"
@@ -323,7 +323,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "libc",
  "redox_syscall",
 ]
@@ -336,9 +336,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -358,16 +358,13 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "markup5ever"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ba2225413ed418d540a2c8247d794f4b0527a021da36f69c05344d716dc44c1"
+checksum = "d0a8096766c229e8c88a3900c9b44b7e06aa7f7343cc229158c3e58ef8f9973a"
 dependencies = [
  "log",
- "phf",
- "phf_codegen",
- "string_cache",
- "string_cache_codegen",
  "tendril",
+ "web_atoms",
 ]
 
 [[package]]
@@ -446,12 +443,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "onig"
-version = "6.4.0"
+name = "once_cell_polyfill"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c4b31c8722ad9171c6d77d3557db078cab2bd50afcc9d09c8b315c59df8ca4f"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "onig"
+version = "6.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.9.1",
  "libc",
  "once_cell",
  "onig_sys",
@@ -459,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "onig_sys"
-version = "69.8.1"
+version = "69.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7"
+checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
 dependencies = [
  "cc",
  "pkg-config",
@@ -469,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -479,9 +482,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -576,9 +579,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -618,11 +621,11 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -764,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -921,6 +924,18 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9c5f0bc545ea3b20b423e33b9b457764de0b3730cd957f6c6aa6c301785f6e"
+dependencies = [
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]

--- a/examples/html2text.rs
+++ b/examples/html2text.rs
@@ -170,7 +170,8 @@ where
             let conf = update_config(conf, &flags);
             #[cfg(feature = "css_ext")]
             let conf = if flags.show_dom {
-                conf.add_agent_css("body { display: x-raw-dom !important; }").unwrap()
+                conf.add_agent_css("body { display: x-raw-dom !important; }")
+                    .unwrap()
             } else {
                 conf
             };

--- a/examples/html2text.rs
+++ b/examples/html2text.rs
@@ -168,6 +168,12 @@ where
         if flags.use_colour {
             let conf = config::rich();
             let conf = update_config(conf, &flags);
+            #[cfg(feature = "css_ext")]
+            let conf = if flags.show_dom {
+                conf.add_agent_css("body { display: x-raw-dom !important; }").unwrap()
+            } else {
+                conf
+            };
             #[cfg(feature = "css")]
             let use_css_colours = !flags.ignore_css_colours;
             #[cfg(not(feature = "css"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1376,8 +1376,6 @@ struct HtmlContext {
     syntax_highlighters: HighlighterMap,
 }
 
-impl HtmlContext {}
-
 // Input to render tree conversion.
 struct RenderInput {
     handle: Handle,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1737,6 +1737,14 @@ fn process_dom_node<T: Write>(
                         // raw DOM.
                         let mut my_computed = computed;
                         my_computed.display = Default::default();
+                        // Preformat it
+                        my_computed.white_space.maybe_update(
+                            false,
+                            StyleOrigin::Agent,
+                            Default::default(),
+                            WhiteSpace::Pre,
+                        );
+                        my_computed.internal_pre = true;
 
                         let new_input = RenderInput {
                             handle: pre_node,

--- a/src/markup5ever_rcdom.rs
+++ b/src/markup5ever_rcdom.rs
@@ -160,6 +160,16 @@ impl Node {
             None
         }
     }
+
+    /// Serialise the node to a writable.
+    pub fn serialize(self: &Rc<Self>, writer: impl io::Write) -> io::Result<()> {
+        html5ever::serialize(
+            writer,
+            &SerializableHandle(self.clone()),
+            Default::default(),
+        )
+    }
+
 }
 
 impl Drop for Node {

--- a/src/markup5ever_rcdom.rs
+++ b/src/markup5ever_rcdom.rs
@@ -166,7 +166,11 @@ impl Node {
         html5ever::serialize(
             writer,
             &SerializableHandle(self.clone()),
-            Default::default(),
+            html5ever::serialize::SerializeOpts {
+                scripting_enabled: true,
+                traversal_scope: html5ever::serialize::TraversalScope::IncludeNode,
+                create_missing_parent: false,
+            }
         )
     }
 
@@ -311,7 +315,11 @@ impl RcDom {
         html5ever::serialize(
             writer,
             &SerializableHandle(self.document.clone()),
-            Default::default(),
+            html5ever::serialize::SerializeOpts {
+                scripting_enabled: true,
+                traversal_scope: html5ever::serialize::TraversalScope::IncludeNode,
+                create_missing_parent: false,
+            }
         )
     }
 

--- a/src/markup5ever_rcdom.rs
+++ b/src/markup5ever_rcdom.rs
@@ -170,10 +170,9 @@ impl Node {
                 scripting_enabled: true,
                 traversal_scope: html5ever::serialize::TraversalScope::IncludeNode,
                 create_missing_parent: false,
-            }
+            },
         )
     }
-
 }
 
 impl Drop for Node {
@@ -319,7 +318,7 @@ impl RcDom {
                 scripting_enabled: true,
                 traversal_scope: html5ever::serialize::TraversalScope::IncludeNode,
                 create_missing_parent: false,
-            }
+            },
         )
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,7 +1,7 @@
 use crate::config::Config;
 use crate::render::text_renderer::{PlainDecorator, TaggedString};
 use crate::render::TaggedLineElement;
-use crate::{config, Error, RenderTree};
+use crate::{config, Error};
 
 use super::render::text_renderer::{RichAnnotation, RichDecorator, TaggedLine, TrivialDecorator};
 use super::{from_read, from_read_with_decorator, parse, TextDecorator};
@@ -178,8 +178,9 @@ where
     assert_eq_str!(output, expected);
 }
 
+#[cfg(feature = "css_ext")]
 #[track_caller]
-fn test_html_conf_rendertree<F>(input: &[u8], conf: F, expected: RenderTree)
+fn test_html_conf_rendertree<F>(input: &[u8], conf: F, expected: crate::RenderTree)
 where
     F: Fn(Config<RichDecorator>) -> Config<RichDecorator>,
 {
@@ -3170,6 +3171,7 @@ mod css_ext_tests {
     fn c(ns: &[RenderNode]) -> RenderNode {
         RenderNode::new(RenderNodeInfo::Container(ns.into()))
     }
+    /*
     // Container
     fn c_s(ns: &[RenderNode], st: ComputedStyle) -> RenderNode {
         RenderNode::new_styled(RenderNodeInfo::Container(ns.into()), st)
@@ -3178,16 +3180,19 @@ mod css_ext_tests {
     fn b(ns: &[RenderNode]) -> RenderNode {
         RenderNode::new(RenderNodeInfo::Block(ns.into()))
     }
+    */
     // Container
     fn b_s(ns: &[RenderNode], st: ComputedStyle) -> RenderNode {
         RenderNode::new_styled(RenderNodeInfo::Block(ns.into()), st)
     }
+    /*
     // Pre
     fn pre(text: &str) -> RenderNode {
-        let mut st: ComputedStyle = st().pre();
+        let st: ComputedStyle = st().pre();
 
         RenderNode::new_styled(RenderNodeInfo::Container(vec![t_s(text, st.inherit())]), st)
     }
+    */
     fn d<T: Default>() -> T {
         Default::default()
     }


### PR DESCRIPTION
Overhaul of the syntax highlighting:
* `x-syntax` is no longer limited to `<pre>` elements
* Elements within a syntax-highlighted region are preserved
* Regions with `display: x-raw-dom` can also be highlighted as HTML

Also fix an issue with serialization back to HTML (don't lose the root element).