### PR TITLE
Fix spurious space before orphan words in pre-wrap mode.

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3061,6 +3061,19 @@ at  line  breaks
                     .unwrap()
             },
         );
+
+        test_html_conf(
+            br#"<p class="prewrap">The last line shouldn't have a space at the start</p>"#,
+            r#"The last line shouldn't
+have a space at the
+start
+"#,
+            23,
+            |conf| {
+                conf.add_css(r#".prewrap { white-space: pre-wrap; }"#)
+                    .unwrap()
+            },
+        );
     }
 
     #[test]


### PR DESCRIPTION
In the new test case in tests.rs, the line must be broken before the final word of the paragraph, so that that word appears on a line by itself. If that test is added by itself, without the rest of the changes in this commit, then it will fail, because the final line of the paragraph comes out with a spurious leading space.

The last word of the paragraph differs from everything else because it's written by WrappedBlock::flush() at the end of the paragraph, instead of by a call to flush_word() from within add_text(). And flush() calls flush_word(WhiteSpace::Normal), without any test to see whether Normal was the appropriate ws_mode.

In this case, it wasn't. The whole paragraph is in PreWrap, and in that mode, self.word usually contains a word of the paragraph plus the whitespace that preceded it. flush_word(PreWrap) knows to do the right thing with that (which is why the _second_ line of the 3-line test paragraph comes out with no leading space), but flush_word(Normal) gets confused.

To fix this, I've removed the ws_mode parameter from flush_word completely, instead storing a WhiteSpace alongside every part of the paragraph accumulated so far, including the pending whitespace counted by wslen. So now flush() doesn't have to work out the right ws_mode to pass any more.