### PR TITLE
Update for 0.15.5.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Possible log types:
 
 ### Latest
 
+### 0.15.5
+
+- [fixed] Fix an assertion and some missing styles with rowspan cells in rich mode.
+
 ### 0.15.4
 
 - [added] Support handling `rowspan` in tables.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "html2text"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "argparse",
  "backtrace",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "html2text"
-version = "0.15.4"
+version = "0.15.5"
 authors = ["Chris Emerson <github@mail.nosreme.org>"]
 description = "Render HTML as plain text."
 repository = "https://github.com/jugglerchris/rust-html2text/"


### PR DESCRIPTION
Fixes a bug with tables with rowspan in rich mode. This was caused by an assertion failure, which was there to catch part of missing implementation.