### PR TITLE
Test layout of multiple `<pre>` elements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - run:
           name: Clippy
           command: |
-            cargo clippy
+            cargo clippy --all-features
   build-css:
     docker:
       - image: cimg/rust:1.80.1

--- a/src/css/parser.rs
+++ b/src/css/parser.rs
@@ -786,11 +786,8 @@ fn parse_display(value: &RawValue) -> Result<Display, nom::Err<nom::error::Error
 
 #[cfg(feature = "css_ext")]
 fn parse_syntax(value: &RawValue) -> Result<String, nom::Err<nom::error::Error<&'static str>>> {
-    for tok in &value.tokens {
-        if let Token::Ident(word) = tok {
-            return Ok(word.to_string());
-        }
-        break;
+    if let Some(Token::Ident(word)) = value.tokens.iter().next() {
+        return Ok(word.to_string());
     }
     Err(empty_fail())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1549,7 +1549,7 @@ impl RenderInput {
                 }
             }
 
-            if let Some(offset_range) = get_offset(&full_text, s) {
+            if let Some(offset_range) = get_offset(full_text, s) {
                 node_styles.push((offset_range, style));
             } // else we ignore the highlight.
         }
@@ -1560,7 +1560,7 @@ impl RenderInput {
     // Return the children in the right form
     fn children(&self) -> Vec<RenderInput> {
         #[cfg(feature = "css_ext")]
-        if self.extra_styles.borrow().len() > 0 {
+        if !self.extra_styles.borrow().is_empty() {
             let mut offset = 0;
             let mut result = Vec::new();
             let mut start_style_index = 0;
@@ -1645,7 +1645,7 @@ impl RenderInput {
         RenderInput::do_extract_text(
             &mut result,
             &self.handle,
-            &mut *self.node_lengths.borrow_mut(),
+            &mut self.node_lengths.borrow_mut(),
         );
         result
     }
@@ -2039,7 +2039,7 @@ fn process_dom_node<T: Write>(
                     }
 
                     if let Some(title) = title {
-                        Finished(RenderNode::new_styled(Svg(title.into()), computed))
+                        Finished(RenderNode::new_styled(Svg(title), computed))
                     } else {
                         Nothing
                     }

--- a/src/markup5ever_rcdom.rs
+++ b/src/markup5ever_rcdom.rs
@@ -327,10 +327,7 @@ impl RcDom {
     pub fn get_node_by_path(&self, path: &[usize]) -> Option<Handle> {
         let mut node = self.document.clone();
         for idx in path {
-            node = match node.nth_child(*idx) {
-                Some(new_node) => new_node,
-                None => return None,
-            };
+            node = node.nth_child(*idx)?;
         }
         Some(node)
     }

--- a/src/render/text_renderer.rs
+++ b/src/render/text_renderer.rs
@@ -1410,7 +1410,7 @@ fn get_wrapping_or_insert<'w, D: TextDecorator>(
     wrapping: &'w mut Option<WrappedBlock<Vec<D::Annotation>>>,
     options: &RenderOptions,
     width: usize,
-    default_tag: &Vec<D::Annotation>,
+    default_tag: &[D::Annotation],
 ) -> &'w mut WrappedBlock<Vec<D::Annotation>> {
     wrapping.get_or_insert_with(|| {
         let wwidth = match options.wrap_width {
@@ -1421,7 +1421,7 @@ fn get_wrapping_or_insert<'w, D: TextDecorator>(
             wwidth,
             options.pad_block_width,
             options.allow_width_overflow,
-            default_tag.clone(),
+            default_tag.to_owned(),
         )
     })
 }
@@ -2041,7 +2041,7 @@ impl<D: TextDecorator> Renderer for SubRenderer<D> {
             let mut pos = 0;
             for mut ls in line_sets.into_iter() {
                 if ls.rowspan > 1 {
-                    if let Some(l) = (&ls.lines).get(cell_height) {
+                    if let Some(l) = ls.lines.get(cell_height) {
                         let mut tmppos = pos;
                         for ts in l.clone().into_tagged_line() {
                             let w = ts.width();
@@ -2052,7 +2052,7 @@ impl<D: TextDecorator> Renderer for SubRenderer<D> {
                         next_border.add_text_span(
                             pos,
                             TaggedLineElement::Str(TaggedString {
-                                s: " ".repeat(ls.width).into(),
+                                s: " ".repeat(ls.width),
                                 tag: next_border.tag.clone(),
                             }),
                         );

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1275,6 +1275,50 @@ world
     );
 }
 
+#[test]
+fn test_multi_pre() {
+    test_html(
+        br##"<head><style><!--
+pre
+	{
+	margin:0cm;
+	margin-bottom:.0001pt;
+	}
+--></style></head>
+<body>
+    <pre>&nbsp;</pre>
+    <pre>Senior Security Engineer</pre>
+    <pre>&nbsp;</pre>
+    <pre>Singapore Washington DC</pre>
+    <pre>&nbsp;</pre>
+    <pre>email: x.y@z.com</pre>
+    <pre>&nbsp;</pre>
+    <pre>mobile:33 999999</pre>
+    <pre>phone: 33 999999</pre>
+</body>
+"##,
+        "\u{a0}
+
+Senior Security Engineer
+
+\u{a0}
+
+Singapore Washington DC
+
+\u{a0}
+
+email: x.y@z.com
+
+\u{a0}
+
+mobile:33 999999
+
+phone: 33 999999
+",
+        80,
+    );
+}
+
 // Check that spans work correctly inside <pre>
 #[test]
 fn test_pre_span() {


### PR DESCRIPTION
In commit 634cee8 the rendering of multiple `<pre>` elements changed. This was not covered by a test, and now it is.

On a secondary note, the layout prior to that commit was more in line with how browsers chose to render it. If we remove the css we get `html2text` and Chrome to agree on both pre-634c and post-634c layouting, it's the CSS that makes the difference.
The added fragment is a bit larger than necessary, to show how this appeared in a real email, but we can trim it down to be more minimal.

Sidenote 2, CI is broken on master.