### PR TITLE
Add option to fence tables

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2767,8 +2767,9 @@ fn render_table_tree<T: Write, D: TextDecorator>(
     };
 
     renderer.start_table()?;
+    renderer.table_depth += 1;
 
-    if renderer.options.fence_tables {
+    if renderer.options.fence_tables && renderer.table_depth == 1 {
         renderer.add_inline_text("```")?;
     }
 
@@ -2779,9 +2780,10 @@ fn render_table_tree<T: Write, D: TextDecorator>(
     Ok(TreeMapResult::PendingChildren {
         children: table.into_rows(col_widths, vert_row),
         cons: Box::new(|renderer, _| {
-            if renderer.options.fence_tables {
+            if renderer.options.fence_tables && renderer.table_depth == 1 {
                 renderer.add_inline_text("```")?;
             }
+            renderer.table_depth -= 1;
             Ok(Some(None))
         }),
         prefn: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1495,6 +1495,7 @@ struct HtmlContext {
     min_wrap_width: usize,
     raw: bool,
     draw_borders: bool,
+    fence_tables: bool,
     wrap_links: bool,
     include_link_footnotes: bool,
     use_unicode_strikeout: bool,
@@ -2767,13 +2768,22 @@ fn render_table_tree<T: Write, D: TextDecorator>(
 
     renderer.start_table()?;
 
+    if renderer.options.fence_tables {
+        renderer.add_inline_text("```")?;
+    }
+
     if table_width != 0 && renderer.options.draw_borders {
         renderer.add_horizontal_border_width(table_width)?;
     }
 
     Ok(TreeMapResult::PendingChildren {
         children: table.into_rows(col_widths, vert_row),
-        cons: Box::new(|_, _| Ok(Some(None))),
+        cons: Box::new(|renderer, _| {
+            if renderer.options.fence_tables {
+                renderer.add_inline_text("```")?;
+            }
+            Ok(Some(None))
+        }),
         prefn: None,
         postfn: None,
     })
@@ -2918,6 +2928,7 @@ pub mod config {
         min_wrap_width: usize,
         raw: bool,
         draw_borders: bool,
+        fence_tables: bool,
         wrap_links: bool,
         include_link_footnotes: bool,
         use_unicode_strikeout: bool,
@@ -2944,6 +2955,7 @@ pub mod config {
                 min_wrap_width: self.min_wrap_width,
                 raw: self.raw,
                 draw_borders: self.draw_borders,
+                fence_tables: self.fence_tables,
                 wrap_links: self.wrap_links,
                 include_link_footnotes: self.include_link_footnotes,
                 use_unicode_strikeout: self.use_unicode_strikeout,
@@ -3156,6 +3168,11 @@ pub mod config {
             self.draw_borders = false;
             self
         }
+        /// Wrap tables in code fences (triple backticks)
+        pub fn fence_tables(mut self) -> Self {
+            self.fence_tables = true;
+            self
+        }
         /// Do not wrap links
         pub fn no_link_wrapping(mut self) -> Self {
             self.wrap_links = false;
@@ -3311,6 +3328,7 @@ pub mod config {
             min_wrap_width: MIN_WIDTH,
             raw: false,
             draw_borders: true,
+            fence_tables: false,
             wrap_links: true,
             include_link_footnotes: false,
             use_unicode_strikeout: true,
@@ -3354,6 +3372,7 @@ impl RenderTree {
             allow_width_overflow: context.allow_width_overflow,
             raw: context.raw,
             draw_borders: context.draw_borders,
+            fence_tables: context.fence_tables,
             wrap_links: context.wrap_links,
             include_link_footnotes: context.include_link_footnotes,
             use_unicode_strikeout: context.use_unicode_strikeout,

--- a/src/render/text_renderer.rs
+++ b/src/render/text_renderer.rs
@@ -1386,6 +1386,9 @@ pub(crate) struct RenderOptions {
     /// Whether to draw table borders
     pub draw_borders: bool,
 
+    /// Whether to wrap tables in code fences (triple backticks)
+    pub fence_tables: bool,
+
     /// Whether to wrap links as normal text
     pub wrap_links: bool,
 
@@ -1407,6 +1410,7 @@ impl Default for RenderOptions {
             pad_block_width: Default::default(),
             raw: false,
             draw_borders: true,
+            fence_tables: false,
             wrap_links: true,
             include_link_footnotes: false,
             use_unicode_strikeout: true,

--- a/src/render/text_renderer.rs
+++ b/src/render/text_renderer.rs
@@ -26,6 +26,7 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 pub(crate) struct TextRenderer<D: TextDecorator> {
     subrender: Vec<SubRenderer<D>>,
     links: Vec<String>,
+    pub(crate) table_depth: usize,
 }
 
 impl<D: TextDecorator> Deref for TextRenderer<D> {
@@ -48,6 +49,7 @@ impl<D: TextDecorator> TextRenderer<D> {
         TextRenderer {
             subrender: vec![subrenderer],
             links: Vec::new(),
+            table_depth: 0,
         }
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2587,6 +2587,75 @@ foo
 }
 
 #[test]
+fn test_fence_tables() {
+    test_html_conf(
+        br##"
+   <p>text</p>
+   <table>
+     <tr><th>1</th><th>2</th></tr>
+     <tr><td>3</td><td>4</td></tr>
+     <tr><td>5</td><td>6</td></tr>
+   </table>
+   <p>text</p>
+"##,
+        r#"text
+
+```
+─┬─
+1│2
+─┼─
+3│4
+─┼─
+5│6
+─┴─
+```
+
+text
+"#,
+        12,
+        |c| c.fence_tables(),
+    );
+}
+
+#[test]
+fn test_fence_tables_nested() {
+    test_html_conf(
+        br##"
+   <p>text</p>
+   <table>
+     <tr><th>1</th><th>2</th></tr>
+     <tr>
+       <td>3</td>
+       <td>
+         <table>
+           <tr><td>4</td><td>5</td></tr>
+           <tr><td>6</td><td>7</td></tr>
+         </table>
+       </td>
+     </tr>
+   </table>
+   <p>text</p>
+"##,
+        r#"text
+
+```
+─┬─────
+1│2    
+─┼─┬───
+3│4│5  
+ │─┼───
+ │6│7  
+─┴─┴───
+```
+
+text
+"#,
+        12,
+        |c| c.fence_tables(),
+    );
+}
+
+#[test]
 fn test_rowspan1() {
     test_html(
         br#"<table>


### PR DESCRIPTION
Adds an option to wrap tables inside fences
Example: 
```Rust
fn main() {
    let html = r#"
<table>
  <tr><th>Name</th><th>Age</th><th>City</th></tr>
  <tr><td>Alice</td><td>30</td><td>Berlin</td></tr>
  <tr><td>Bob</td><td>25</td><td>Paris</td></tr>
  <tr><td>Charlie</td><td>35</td><td>London</td></tr>
</table>"#;

    let out = config::plain()
        .fence_tables()
        .string_from_read(html.as_bytes(), 50)
        .unwrap();
    println!("{}", out);
}
```
This makes tables render correctly in Markdown previews:
```
───────┬───┬──────
Name   │Age│City  
───────┼───┼──────
Alice  │30 │Berlin
───────┼───┼──────
Bob    │25 │Paris 
───────┼───┼──────
Charlie│35 │London
───────┴───┴──────
```

instead of:
───────┬───┬──────
Name   │Age│City  
───────┼───┼──────
Alice  │30 │Berlin
───────┼───┼──────
Bob    │25 │Paris 
───────┼───┼──────
Charlie│35 │London
───────┴───┴──────